### PR TITLE
cli: Fix lzma linker flag

### DIFF
--- a/cli/.cargo/config.toml
+++ b/cli/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-llzma"]

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // On Linux, libunwind-ptrace.so may depend on liblzma.
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=lzma");
+    }
+}


### PR DESCRIPTION
This fixes the release workflow failure on Ubuntu 22.04 where linking failed with undefined references to lzma functions. The issue occurred because cargo-dist runs from the repository root and doesn't find .cargo/config.toml in subdirectories.