### PR TITLE
Switch AgentFS SDK to use identifier-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,26 @@ Read more about the motivation for AgentFS in the announcement [blog post](https
 Initialize an agent filesystem:
 
 ```bash
-$ agentfs init
-Created agent filesystem: agent.db
+$ agentfs init my-agent
+Created agent filesystem: .agentfs/my-agent.db
+Agent ID: my-agent
 ```
 
-Inspect the agent filesystem from outside:
+Inspect the agent filesystem:
 
 ```bash
-$ agentfs fs ls
+$ agentfs fs ls my-agent
+Using agent: my-agent
 f hello.txt
 
-$ agentfs fs cat hello.txt
+$ agentfs fs cat my-agent hello.txt
+hello from agent
+```
+
+You can also use a database path directly:
+
+```bash
+$ agentfs fs cat .agentfs/my-agent.db hello.txt
 hello from agent
 ```
 
@@ -80,7 +89,12 @@ Use it in your agent code:
 ```typescript
 import { AgentFS } from 'agentfs-sdk';
 
-const agent = await AgentFS.open('./agent.db');
+// Persistent storage with identifier
+const agent = await AgentFS.open({ id: 'my-agent' });
+// Creates: .agentfs/my-agent.db
+
+// Or use ephemeral in-memory database
+const ephemeralAgent = await AgentFS.open();
 
 // Key-value operations
 await agent.kv.set('user:preferences', { theme: 'dark' });

--- a/cli/tests/test-run-bash.sh
+++ b/cli/tests/test-run-bash.sh
@@ -3,16 +3,16 @@ set -e
 
 echo -n "TEST interactive bash session... "
 
-TEST_DB="test_agent.db"
+TEST_AGENT_ID="test-bash-agent"
 
 # Clean up any existing test database
-rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm"
+rm -rf .agentfs
 
 # Initialize the database using agentfs init
-cargo run -- init "$TEST_DB" > /dev/null 2>&1
+cargo run -- init "$TEST_AGENT_ID" > /dev/null 2>&1
 
 # Run bash session: write a file and read it back (like README example)
-output=$(cargo run -- run --mount type=sqlite,src="$TEST_DB",dst=/agent /bin/bash -c '
+output=$(cargo run -- run --mount type=sqlite,src=".agentfs/${TEST_AGENT_ID}.db",dst=/agent /bin/bash -c '
 echo "hello from agent" > /agent/hello.txt
 cat /agent/hello.txt
 ' 2>&1)
@@ -21,11 +21,11 @@ cat /agent/hello.txt
 echo "$output" | grep -q "hello from agent" || {
     echo "FAILED"
     echo "$output"
-    rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm"
+    rm -rf .agentfs
     exit 1
 }
 
 # Cleanup
-rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm"
+rm -rf .agentfs
 
 echo "OK"

--- a/examples/claude-agent/research-assistant/.env.example
+++ b/examples/claude-agent/research-assistant/.env.example
@@ -1,5 +1,5 @@
 # Anthropic API Key (required)
 ANTHROPIC_API_KEY=your-api-key-here
 
-# Optional: Custom AgentFS database path
-# AGENTFS_DB=agentfs.db
+# Optional: Custom AgentFS agent ID
+# AGENTFS_ID=research-assistant

--- a/examples/claude-agent/research-assistant/.gitignore
+++ b/examples/claude-agent/research-assistant/.gitignore
@@ -8,10 +8,8 @@ dist/
 .env
 .env.local
 
-# AgentFS database
-agentfs.db
-agentfs.db-shm
-agentfs.db-wal
+# AgentFS local databases
+.agentfs/
 
 # IDE
 .vscode/

--- a/examples/claude-agent/research-assistant/src/utils/agentfs.ts
+++ b/examples/claude-agent/research-assistant/src/utils/agentfs.ts
@@ -4,8 +4,8 @@ let instance: AgentFS | null = null;
 
 export async function getAgentFS(): Promise<AgentFS> {
   if (!instance) {
-    const dbPath = process.env.AGENTFS_DB || 'agentfs.db';
-    instance = await AgentFS.open(dbPath);
+    const id = process.env.AGENTFS_ID || 'research-assistant';
+    instance = await AgentFS.open({ id });
   }
   return instance;
 }

--- a/examples/mastra/research-assistant/.gitignore
+++ b/examples/mastra/research-assistant/.gitignore
@@ -6,3 +6,6 @@ dist
 .env
 *.db
 *.db-*
+
+# AgentFS local databases
+.agentfs/

--- a/examples/mastra/research-assistant/src/mastra/utils/agentfs.ts
+++ b/examples/mastra/research-assistant/src/mastra/utils/agentfs.ts
@@ -4,8 +4,8 @@ let instance: AgentFS | null = null;
 
 export async function getAgentFS(): Promise<AgentFS> {
   if (!instance) {
-    const dbPath = process.env.AGENTFS_DB || 'agentfs.db';
-    instance = await AgentFS.open(dbPath);
+    const id = process.env.AGENTFS_ID || 'research-assistant';
+    instance = await AgentFS.open({ id });
   }
   return instance;
 }

--- a/examples/openai-agents/research-assistant/.env.example
+++ b/examples/openai-agents/research-assistant/.env.example
@@ -1,5 +1,5 @@
 # OpenAI API Key (required)
 OPENAI_API_KEY=your-api-key-here
 
-# Optional: Custom AgentFS database path
-# AGENTFS_DB=agentfs.db
+# Optional: Custom AgentFS agent ID
+# AGENTFS_ID=research-assistant

--- a/examples/openai-agents/research-assistant/.gitignore
+++ b/examples/openai-agents/research-assistant/.gitignore
@@ -3,3 +3,6 @@ dist/
 .env
 *.db
 *.log
+
+# AgentFS local databases
+.agentfs/

--- a/examples/openai-agents/research-assistant/src/utils/agentfs.ts
+++ b/examples/openai-agents/research-assistant/src/utils/agentfs.ts
@@ -4,8 +4,8 @@ let instance: AgentFS | null = null;
 
 export async function getAgentFS(): Promise<AgentFS> {
   if (!instance) {
-    const dbPath = process.env.AGENTFS_DB || 'agentfs.db';
-    instance = await AgentFS.open(dbPath);
+    const id = process.env.AGENTFS_ID || 'research-assistant';
+    instance = await AgentFS.open({ id });
   }
   return instance;
 }

--- a/sandbox/Cargo.lock
+++ b/sandbox/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentfs-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/sdk/rust/.gitignore
+++ b/sdk/rust/.gitignore
@@ -1,1 +1,4 @@
 target
+
+# AgentFS local databases
+.agentfs/

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -3,12 +3,36 @@ pub mod kvstore;
 pub mod toolcalls;
 
 use anyhow::Result;
+use std::path::Path;
 use std::sync::Arc;
 use turso::{Builder, Connection};
 
 pub use filesystem::{Filesystem, Stats};
 pub use kvstore::KvStore;
 pub use toolcalls::{ToolCall, ToolCallStats, ToolCallStatus, ToolCalls};
+
+/// Configuration options for opening an AgentFS instance
+#[derive(Debug, Clone, Default)]
+pub struct AgentFSOptions {
+    /// Optional unique identifier for the agent.
+    /// - If Some(id): Creates persistent storage at `.agentfs/{id}.db`
+    /// - If None: Uses ephemeral in-memory database
+    pub id: Option<String>,
+}
+
+impl AgentFSOptions {
+    /// Create options for a persistent agent with the given ID
+    pub fn with_id(id: impl Into<String>) -> Self {
+        Self {
+            id: Some(id.into()),
+        }
+    }
+
+    /// Create options for an ephemeral in-memory agent
+    pub fn ephemeral() -> Self {
+        Self { id: None }
+    }
+}
 
 /// The main AgentFS SDK struct
 ///
@@ -22,10 +46,70 @@ pub struct AgentFS {
 }
 
 impl AgentFS {
-    /// Create a new AgentFS instance
+    /// Open an AgentFS instance
+    ///
+    /// # Arguments
+    /// * `options` - Configuration options (use Default::default() for ephemeral)
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use agentfs_sdk::{AgentFS, AgentFSOptions};
+    ///
+    /// # async fn example() -> anyhow::Result<()> {
+    /// // Persistent storage
+    /// let agent = AgentFS::open(AgentFSOptions::with_id("my-agent")).await?;
+    ///
+    /// // Ephemeral in-memory
+    /// let agent = AgentFS::open(AgentFSOptions::ephemeral()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn open(options: AgentFSOptions) -> Result<Self> {
+        // Determine database path based on id
+        let db_path = if let Some(id) = options.id {
+            // Validate agent ID to prevent path traversal attacks
+            if !Self::validate_agent_id(&id) {
+                anyhow::bail!(
+                    "Invalid agent ID '{}'. Agent IDs must contain only alphanumeric characters, hyphens, and underscores.",
+                    id
+                );
+            }
+
+            // Ensure .agentfs directory exists
+            let agentfs_dir = Path::new(".agentfs");
+            if !agentfs_dir.exists() {
+                std::fs::create_dir_all(agentfs_dir)?;
+            }
+            format!(".agentfs/{}.db", id)
+        } else {
+            // No id = ephemeral in-memory database
+            ":memory:".to_string()
+        };
+
+        let db = Builder::new_local(&db_path).build().await?;
+        let conn = db.connect()?;
+        let conn = Arc::new(conn);
+
+        let kv = KvStore::from_connection(conn.clone()).await?;
+        let fs = Filesystem::from_connection(conn.clone()).await?;
+        let tools = ToolCalls::from_connection(conn.clone()).await?;
+
+        Ok(Self {
+            conn,
+            kv,
+            fs,
+            tools,
+        })
+    }
+
+    /// Create a new AgentFS instance (deprecated, use `open` instead)
     ///
     /// # Arguments
     /// * `db_path` - Path to the SQLite database file (use ":memory:" for in-memory database)
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use AgentFS::open with AgentFSOptions instead"
+    )]
     pub async fn new(db_path: &str) -> Result<Self> {
         let db = Builder::new_local(db_path).build().await?;
         let conn = db.connect()?;
@@ -47,6 +131,15 @@ impl AgentFS {
     pub fn get_connection(&self) -> Arc<Connection> {
         self.conn.clone()
     }
+
+    /// Validates an agent ID to prevent path traversal and ensure safe filesystem operations.
+    /// Returns true if the ID contains only alphanumeric characters, hyphens, and underscores.
+    fn validate_agent_id(id: &str) -> bool {
+        !id.is_empty()
+            && id
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    }
 }
 
 #[cfg(test)]
@@ -55,14 +148,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_agentfs_creation() {
-        let agentfs = AgentFS::new(":memory:").await.unwrap();
+        let agentfs = AgentFS::open(AgentFSOptions::ephemeral()).await.unwrap();
         // Just verify we can get the connection
         let _conn = agentfs.get_connection();
     }
 
     #[tokio::test]
+    async fn test_agentfs_with_id() {
+        let agentfs = AgentFS::open(AgentFSOptions::with_id("test-agent"))
+            .await
+            .unwrap();
+        // Just verify we can get the connection
+        let _conn = agentfs.get_connection();
+
+        // Cleanup
+        let _ = std::fs::remove_file(".agentfs/test-agent.db");
+        let _ = std::fs::remove_file(".agentfs/test-agent.db-shm");
+        let _ = std::fs::remove_file(".agentfs/test-agent.db-wal");
+    }
+
+    #[tokio::test]
     async fn test_kv_operations() {
-        let agentfs = AgentFS::new(":memory:").await.unwrap();
+        let agentfs = AgentFS::open(AgentFSOptions::ephemeral()).await.unwrap();
 
         // Set a value
         agentfs.kv.set("test_key", &"test_value").await.unwrap();
@@ -81,7 +188,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_filesystem_operations() {
-        let agentfs = AgentFS::new(":memory:").await.unwrap();
+        let agentfs = AgentFS::open(AgentFSOptions::ephemeral()).await.unwrap();
 
         // Create a directory
         agentfs.fs.mkdir("/test_dir").await.unwrap();
@@ -115,7 +222,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tool_calls() {
-        let agentfs = AgentFS::new(":memory:").await.unwrap();
+        let agentfs = AgentFS::open(AgentFSOptions::ephemeral()).await.unwrap();
 
         // Start a tool call
         let id = agentfs

--- a/sdk/typescript/.gitignore
+++ b/sdk/typescript/.gitignore
@@ -19,6 +19,9 @@ dist/
 *.db-shm
 *.db-wal
 
+# AgentFS local databases
+.agentfs/
+
 # Logs
 *.log
 npm-debug.log*

--- a/sdk/typescript/examples/filesystem/index.ts
+++ b/sdk/typescript/examples/filesystem/index.ts
@@ -1,7 +1,8 @@
 import { AgentFS } from "agentfs-sdk";
 
 async function main() {
-  const agentfs = await AgentFS.open(":memory:");
+  // Initialize AgentFS with persistent storage
+  const agentfs = await AgentFS.open({ id: "filesystem-demo" });
 
   // Write a file
   console.log("Writing file...");

--- a/sdk/typescript/examples/kvstore/index.ts
+++ b/sdk/typescript/examples/kvstore/index.ts
@@ -1,8 +1,8 @@
 import { AgentFS } from "agentfs-sdk";
 
 async function main() {
-  // Initialize AgentFS (in-memory for this example)
-  const agentfs = await AgentFS.open(":memory:");
+  // Initialize AgentFS with persistent storage
+  const agentfs = await AgentFS.open({ id: "kvstore-demo" });
 
   console.log("=== KvStore Example ===\n");
 

--- a/sdk/typescript/examples/toolcalls/index.ts
+++ b/sdk/typescript/examples/toolcalls/index.ts
@@ -1,8 +1,8 @@
 import { AgentFS } from '../../src';
 
 async function main() {
-  // Create an agent with an in-memory database
-  const agentfs = await AgentFS.open(':memory:');
+  // Create an agent with persistent storage
+  const agentfs = await AgentFS.open({ id: 'toolcalls-demo' });
 
   console.log('=== Tool Call Tracking Example ===\n');
 

--- a/sdk/typescript/tests/index.test.ts
+++ b/sdk/typescript/tests/index.test.ts
@@ -1,77 +1,93 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AgentFS } from '../src/index';
-import { mkdtempSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { existsSync, rmSync } from 'fs';
 
 describe('AgentFS Integration Tests', () => {
   let agent: AgentFS;
-  let tempDir: string;
-  let dbPath: string;
+  const testId = 'test-agent';
 
   beforeEach(async () => {
-    // Create temporary directory for test database
-    tempDir = mkdtempSync(join(tmpdir(), 'agentfs-test-'));
-    dbPath = join(tempDir, 'test.db');
-
-    // Initialize AgentFS
-    agent = await AgentFS.open(dbPath);
+    // Initialize AgentFS with a test id
+    agent = await AgentFS.open({ id: testId });
   });
 
-  afterEach(() => {
-    // Clean up temporary directories
-    try {
-      rmSync(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
+  afterEach(async () => {
+    // Close the agent
+    await agent.close();
+    // Clean up test database files
+    cleanupAgentFiles(testId);
   });
 
   describe('Initialization', () => {
-    it('should successfully initialize with a file path', async () => {
+    it('should successfully initialize with an id', async () => {
       expect(agent).toBeDefined();
       expect(agent).toBeInstanceOf(AgentFS);
     });
 
-    it('should initialize with in-memory database', async () => {
-      const memoryAgent = await AgentFS.open(':memory:');
+    it('should initialize with ephemeral in-memory database', async () => {
+      const memoryAgent = await AgentFS.open();
       expect(memoryAgent).toBeDefined();
       expect(memoryAgent).toBeInstanceOf(AgentFS);
+      await memoryAgent.close();
     });
 
-    it('should allow multiple instances with different databases', async () => {
-      const dbPath2 = join(tempDir, 'test2.db');
-      const agent2 = await AgentFS.open(dbPath2);
+    it('should allow multiple instances with different ids', async () => {
+      const agent2 = await AgentFS.open({ id: 'test-agent-2' });
 
       expect(agent).toBeDefined();
       expect(agent2).toBeDefined();
       expect(agent).not.toBe(agent2);
+
+      await agent2.close();
+      // Clean up second agent's database
+      cleanupAgentFiles('test-agent-2');
     });
   });
 
   describe('Database Persistence', () => {
-    it('should persist database file to disk', async () => {
-      // Use the agent from beforeEach
-      // Check that database file exists
-      const fs = require('fs');
-      expect(fs.existsSync(dbPath)).toBe(true);
+    it('should persist database file to .agentfs directory', async () => {
+      // Check that database file exists in .agentfs directory
+      const dbPath = `.agentfs/${testId}.db`;
+      expect(existsSync(dbPath)).toBe(true);
     });
 
-    it('should reuse existing database file', async () => {
+    it('should reuse existing database file with same id', async () => {
       // Create first instance and write data
-      const testDbPath = join(tempDir, 'persistence-test.db');
-      const agent1 = await AgentFS.open(testDbPath);
+      const persistenceTestId = 'persistence-test';
+      const agent1 = await AgentFS.open({ id: persistenceTestId });
       await agent1.kv.set('test', 'value1');
       await agent1.close();
 
-      // Create second instance with same path - should be able to read the data
-      const agent2 = await AgentFS.open(testDbPath);
+      // Create second instance with same id - should be able to read the data
+      const agent2 = await AgentFS.open({ id: persistenceTestId });
       const value = await agent2.kv.get('test');
 
       expect(agent1).toBeDefined();
       expect(agent2).toBeDefined();
       expect(value).toBe('value1');
+
+      await agent2.close();
+
+      // Clean up
+      cleanupAgentFiles(persistenceTestId);
     });
   });
-
 });
+
+/**
+ * Helper function to clean up agent database files and related SQLite files
+ * @param id The agent ID to clean up
+ */
+function cleanupAgentFiles(id: string): void {
+  const dbPath = `.agentfs/${id}.db`;
+  try {
+    // Remove database file and SQLite WAL files
+    [dbPath, `${dbPath}-shm`, `${dbPath}-wal`].forEach(file => {
+      if (existsSync(file)) {
+        rmSync(file, { force: true });
+      }
+    });
+  } catch {
+    // Ignore cleanup errors
+  }
+}


### PR DESCRIPTION
This switches the AgentFS SDK to use identifier-based API instead of SQLite database files in preparation for adding sync to Turso Cloud. With explicit agent filesystem identifiers, we can have a naming convention to manage database files on the cloud, reducing agent configuration.

Before this change, you would open an agent filesystem with:

```typescript
// Persisten filesystem:
const agent = await AgentFS.open('./agent.db');

// Ephemeral filesystem:
const agent = await AgentFS.open(':memory':);
```

Now you do the same with:

```typescript
// Persistent filesystem (creates `.agentfs/my-agent.db`):
const agent = await AgentFS.open({ id: 'my-agent' });

// Ephemeral filesystem:
const agent = await AgentFS.open();
```