### PR TITLE
sdk/typescript: Add support for custom agent filesystem path

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -249,12 +249,14 @@ npm install agentfs-sdk
 ```typescript
 import { AgentFS } from 'agentfs-sdk';
 
-// Open agent filesystem with persistent storage
+// Using id (creates .agentfs/my-agent.db)
 const agent = await AgentFS.open({ id: 'my-agent' });
-// Creates: .agentfs/my-agent.db
 
-// Or use ephemeral in-memory database
-const ephemeralAgent = await AgentFS.open();
+// Using id with custom path
+const agent2 = await AgentFS.open({ id: 'my-agent', path: './data/mydb.db' });
+
+// Using path only
+const agent3 = await AgentFS.open({ path: './data/mydb.db' });
 
 // Key-value operations
 await agent.kv.set('user:name', 'Alice');
@@ -295,17 +297,20 @@ AgentFS.open(options?: AgentFSOptions): Promise<AgentFS>
 Opens or creates an agent filesystem.
 
 **Parameters:**
-- `options?: AgentFSOptions` - Optional configuration
-  - `id?: string` - Agent identifier (creates `.agentfs/{id}.db`)
-  - If no options provided, uses ephemeral in-memory database
+- `options: AgentFSOptions` - Configuration (at least `id` or `path` required)
+  - `id?: string` - Agent identifier (if no `path`, creates `.agentfs/{id}.db`)
+  - `path?: string` - Explicit database path (takes precedence over id-based path)
 
 **Examples:**
 ```typescript
-// Persistent storage with agent ID
+// Using id (creates .agentfs/my-agent.db)
 const agent = await AgentFS.open({ id: 'my-agent' });
 
-// Ephemeral in-memory database
-const temp = await AgentFS.open();
+// Using id with custom path
+const agent2 = await AgentFS.open({ id: 'my-agent', path: './data/mydb.db' });
+
+// Using path only
+const agent3 = await AgentFS.open({ path: './data/mydb.db' });
 ```
 
 **Properties:**
@@ -320,9 +325,12 @@ const temp = await AgentFS.open();
 **AgentFSOptions Interface:**
 ```typescript
 interface AgentFSOptions {
-  id?: string;  // Optional agent identifier
+  id?: string;    // Agent identifier (if no path, creates .agentfs/{id}.db)
+  path?: string;  // Explicit database path (takes precedence over id-based path)
 }
 ```
+
+Note: At least one of `id` or `path` must be provided.
 
 #### Key-Value Store API
 

--- a/sdk/typescript/tests/index.test.ts
+++ b/sdk/typescript/tests/index.test.ts
@@ -24,11 +24,18 @@ describe('AgentFS Integration Tests', () => {
       expect(agent).toBeInstanceOf(AgentFS);
     });
 
-    it('should initialize with ephemeral in-memory database', async () => {
-      const memoryAgent = await AgentFS.open();
-      expect(memoryAgent).toBeDefined();
-      expect(memoryAgent).toBeInstanceOf(AgentFS);
-      await memoryAgent.close();
+    it('should initialize with explicit path', async () => {
+      const pathAgent = await AgentFS.open({ path: ':memory:' });
+      expect(pathAgent).toBeDefined();
+      expect(pathAgent).toBeInstanceOf(AgentFS);
+      await pathAgent.close();
+    });
+
+    it('should require at least id or path', async () => {
+      // @ts-expect-error - Testing runtime validation for JS users
+      await expect(AgentFS.open({})).rejects.toThrow(
+        "AgentFS.open() requires at least 'id' or 'path'"
+      );
     });
 
     it('should allow multiple instances with different ids', async () => {


### PR DESCRIPTION
The AgentFS ID is a good default convention and needed for, for example, future sync. However, users have different preferences on how to organize the agent filesystem database files on the host, so allow them to override the automatic path with a custom one.

Fixes #54