### PR TITLE
Fix broken pipe panic when piping output to head

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,10 +17,13 @@ turso = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 parking_lot = "0.12.5"
 
+# Unix dependencies
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 # Linux-only dependencies for FUSE functionality
 [target.'cfg(target_os = "linux")'.dependencies]
 fuser = { version = "0.15", default-features = false, features = ["abi-7-23"] }
-libc = "0.2"
 
 # Sandbox dependencies - Linux x86_64 only (requires libunwind-ptrace)
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -342,6 +342,8 @@ async fn init_database(id: Option<String>, force: bool) -> AnyhowResult<()> {
 }
 
 fn main() {
+    reset_sigpipe();
+
     let args = Args::parse();
 
     match args.command {
@@ -408,3 +410,15 @@ fn main() {
         }
     }
 }
+
+/// Reset SIGPIPE to the default behavior (terminate the process) so that
+/// piping output to tools like `head` doesn't cause a panic.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}


### PR DESCRIPTION
Reset SIGPIPE to default behavior (SIG_DFL) at program start so that writing to a closed pipe terminates cleanly instead of panicking.