### PR TITLE
Make libfuse.dylib a weak runtime dependency on macOS

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -7,4 +7,12 @@ fn main() {
         // libgcc_s provides _Unwind_RaiseException and other exception handling symbols
         println!("cargo:rustc-link-lib=dylib=gcc_s");
     }
+
+    // macOS: Weak-link libfuse so the binary can load without macFUSE installed.
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-arg=-Wl,-weak-lfuse");
+        println!("cargo:rustc-link-search=/usr/local/lib");
+        println!("cargo:rustc-link-search=/Library/Frameworks/macFUSE.framework/Versions/A");
+    }
 }


### PR DESCRIPTION
Add weak linking for libfuse on macOS so the binary can load even when macFUSE is not installed. The mount command now checks for libfuse availability at runtime using dlopen and provides a helpful error message if macFUSE is missing.