### PR TITLE
add openWith method

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -88,6 +88,10 @@ export class AgentFS {
     // Connect to the database to ensure it's created
     await db.connect();
 
+    return await AgentFS.openWith(db);
+  }
+
+  static async openWith(db: Database): Promise<AgentFS> {
     // Create subsystems
     const kv = new KvStore(db);
     const fs = new Filesystem(db);


### PR DESCRIPTION
This allows to provide turso database configured externally (for example, with sync support)

```js
const db = await connect({ path: options.agentdb, url: options.url, authToken: options.auth });
await db.pull();
const agentfs = await AgentFS.openWith(db);
```