### PR TITLE
sdk/typescript: Remove ready() method from the API

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -92,17 +92,11 @@ export class AgentFS {
   }
 
   static async openWith(db: Database): Promise<AgentFS> {
-    // Create subsystems
-    const kv = new KvStore(db);
-    const fs = new Filesystem(db);
-    const tools = new ToolCalls(db);
-
-    // Wait for all subsystems to initialize
-    await kv.ready();
-    await fs.ready();
-    await tools.ready();
-
-    // Return fully initialized instance
+    const [kv, fs, tools] = await Promise.all([
+      KvStore.fromDatabase(db),
+      Filesystem.fromDatabase(db),
+      ToolCalls.fromDatabase(db),
+    ]);
     return new AgentFS(db, kv, fs, tools);
   }
 

--- a/sdk/typescript/tests/kvstore.test.ts
+++ b/sdk/typescript/tests/kvstore.test.ts
@@ -18,7 +18,8 @@ describe('KvStore Integration Tests', () => {
 
     // Initialize database and KvStore
     db = new Database(dbPath);
-    kvStore = new KvStore(db);
+    await db.connect();
+    kvStore = await KvStore.fromDatabase(db);
   });
 
   afterEach(() => {
@@ -191,7 +192,7 @@ describe('KvStore Integration Tests', () => {
       await kvStore.set('persist-key', 'persist-value');
 
       // Create new KvStore instance with same database
-      const newKvStore = new KvStore(db);
+      const newKvStore = await KvStore.fromDatabase(db);
       const value = await newKvStore.get('persist-key');
       expect(value).toBe('persist-value');
     });

--- a/sdk/typescript/tests/toolcalls.test.ts
+++ b/sdk/typescript/tests/toolcalls.test.ts
@@ -18,7 +18,8 @@ describe('ToolCalls Integration Tests', () => {
 
     // Initialize database and ToolCalls
     db = new Database(dbPath);
-    toolCalls = new ToolCalls(db);
+    await db.connect();
+    toolCalls = await ToolCalls.fromDatabase(db);
   });
 
   afterEach(() => {
@@ -284,7 +285,7 @@ describe('ToolCalls Integration Tests', () => {
       await toolCalls.success(id, { result: 'ok' });
 
       // Create new ToolCalls instance with same database
-      const newToolCalls = new ToolCalls(db);
+      const newToolCalls = await ToolCalls.fromDatabase(db);
       const toolCall = await newToolCalls.get(id);
 
       expect(toolCall).toBeDefined();


### PR DESCRIPTION
The ready() method is just sloppy API created by Claude from the AgentFS specification. Let's remove it in preparation for some more API improvements.