### PR TITLE
use same tursodb version across all agentfs components

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -239,6 +239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bloom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
+dependencies = [
+ "bit-vec",
 ]
 
 [[package]]
@@ -646,6 +661,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -1780,6 +1801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e65c75143ce5d47c55b510297eeb1182f3c739b6043c537670e9fc18612dae"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,9 +2618,8 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c670345a51c5df2ebb0a582c9af67dea98192c8fd82ca2c50aca34b342bf0c10"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "mimalloc",
  "thiserror 2.0.17",
@@ -2601,20 +2630,21 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5a3044961c822886d08cbc94f5519524213b877f65fb66ab70133ed3c0a36d"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "aegis",
  "aes",
  "aes-gcm",
  "arc-swap",
  "bitflags 2.10.0",
+ "bloom",
  "built",
  "bytemuck",
  "cfg_block",
  "chrono",
  "crossbeam-skiplist",
+ "either",
  "fallible-iterator",
  "hex",
  "intrusive-collections",
@@ -2628,6 +2658,7 @@ dependencies = [
  "paste",
  "polling",
  "rand",
+ "rapidhash",
  "regex",
  "regex-syntax",
  "roaring",
@@ -2640,6 +2671,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
+ "tracing-subscriber",
  "turso_ext",
  "turso_macros",
  "turso_parser",
@@ -2650,9 +2682,8 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c744b2d657542911d6b1708f8aa2f047601cc0d452af8cd2d7f8fb1c05d40730"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -2661,9 +2692,8 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4631f270381e6153833ab491b42fca3a1dbaad0f657a12ea1d676dec8f71e7b1"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2672,9 +2702,8 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64ae3d49b989ed156abe143ae0244d0f239f67fc42da72806369a567f295750"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "bitflags 2.10.0",
  "miette",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ agentfs-sdk = { path = "../sdk/rust" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1.0"
-turso = "0.3.2"
+turso = { git = "https://github.com/tursodatabase/turso", tag = "v0.4.0-pre.16" }
 serde = { version = "1.0", features = ["derive"] }
 parking_lot = "0.12.5"
 clap_complete = { version = "=4.5.61", features = ["unstable-dynamic"] }

--- a/sandbox/Cargo.lock
+++ b/sandbox/Cargo.lock
@@ -168,6 +168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bloom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
+dependencies = [
+ "bit-vec",
 ]
 
 [[package]]
@@ -496,6 +511,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -1555,6 +1576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e65c75143ce5d47c55b510297eeb1182f3c739b6043c537670e9fc18612dae"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,9 +2376,8 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c670345a51c5df2ebb0a582c9af67dea98192c8fd82ca2c50aca34b342bf0c10"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "mimalloc",
  "thiserror 2.0.17",
@@ -2359,20 +2388,21 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5a3044961c822886d08cbc94f5519524213b877f65fb66ab70133ed3c0a36d"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "aegis",
  "aes",
  "aes-gcm",
  "arc-swap",
  "bitflags 2.10.0",
+ "bloom",
  "built",
  "bytemuck",
  "cfg_block",
  "chrono",
  "crossbeam-skiplist",
+ "either",
  "fallible-iterator",
  "hex",
  "intrusive-collections",
@@ -2386,6 +2416,7 @@ dependencies = [
  "paste",
  "polling",
  "rand",
+ "rapidhash",
  "regex",
  "regex-syntax",
  "roaring",
@@ -2398,6 +2429,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
+ "tracing-subscriber",
  "turso_ext",
  "turso_macros",
  "turso_parser",
@@ -2408,9 +2440,8 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c744b2d657542911d6b1708f8aa2f047601cc0d452af8cd2d7f8fb1c05d40730"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -2419,9 +2450,8 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4631f270381e6153833ab491b42fca3a1dbaad0f657a12ea1d676dec8f71e7b1"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2430,9 +2460,8 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64ae3d49b989ed156abe143ae0244d0f239f67fc42da72806369a567f295750"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "bitflags 2.10.0",
  "miette",

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -110,10 +110,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bloom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
+dependencies = [
+ "bit-vec",
+]
 
 [[package]]
 name = "built"
@@ -289,6 +304,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -921,6 +942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e65c75143ce5d47c55b510297eeb1182f3c739b6043c537670e9fc18612dae"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,9 +1354,8 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c670345a51c5df2ebb0a582c9af67dea98192c8fd82ca2c50aca34b342bf0c10"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "mimalloc",
  "thiserror 2.0.17",
@@ -1337,20 +1366,21 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5a3044961c822886d08cbc94f5519524213b877f65fb66ab70133ed3c0a36d"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "aegis",
  "aes",
  "aes-gcm",
  "arc-swap",
  "bitflags",
+ "bloom",
  "built",
  "bytemuck",
  "cfg_block",
  "chrono",
  "crossbeam-skiplist",
+ "either",
  "fallible-iterator",
  "hex",
  "intrusive-collections",
@@ -1364,6 +1394,7 @@ dependencies = [
  "paste",
  "polling",
  "rand",
+ "rapidhash",
  "regex",
  "regex-syntax",
  "roaring",
@@ -1376,6 +1407,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
+ "tracing-subscriber",
  "turso_ext",
  "turso_macros",
  "turso_parser",
@@ -1386,9 +1418,8 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c744b2d657542911d6b1708f8aa2f047601cc0d452af8cd2d7f8fb1c05d40730"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -1397,9 +1428,8 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4631f270381e6153833ab491b42fca3a1dbaad0f657a12ea1d676dec8f71e7b1"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1408,9 +1438,8 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64ae3d49b989ed156abe143ae0244d0f239f67fc42da72806369a567f295750"
+version = "0.4.0-pre.16"
+source = "git+https://github.com/tursodatabase/turso?tag=v0.4.0-pre.16#574c8258b008ebb2c651cfc4a6c8200c7a76f923"
 dependencies = [
  "bitflags",
  "miette",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -6,7 +6,7 @@ description = "AgentFS SDK for Rust"
 license = "MIT"
 
 [dependencies]
-turso = "0.3.2"
+turso = { git = "https://github.com/tursodatabase/turso", tag = "v0.4.0-pre.16" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0-pre.6",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database": "^0.3.2"
+        "@tursodatabase/database": "^0.4.0-pre.16"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -790,30 +790,30 @@
       "license": "MIT"
     },
     "node_modules/@tursodatabase/database": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database/-/database-0.3.2.tgz",
-      "integrity": "sha512-rco3onkA5/hFCleiq5DFqc5LDeL8rNSbWbDvA9c5yIRV63qn9/74fXyInBaI4Wy5OxGgA/FSjCzsy1NurQ9fSw==",
+      "version": "0.4.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@tursodatabase/database/-/database-0.4.0-pre.16.tgz",
+      "integrity": "sha512-mbUt04HUCHKeck8Rgx6yogvzKc94yP9s3hIgvMFCq8dP7dTZV4xXaO4W0cFvkqxiy9hBuaB5KClq7uMDJ8Ptcw==",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.3.2"
+        "@tursodatabase/database-common": "^0.4.0-pre.16"
       },
       "optionalDependencies": {
-        "@tursodatabase/database-darwin-arm64": "0.3.2",
-        "@tursodatabase/database-linux-arm64-gnu": "0.3.2",
-        "@tursodatabase/database-linux-x64-gnu": "0.3.2",
-        "@tursodatabase/database-win32-x64-msvc": "0.3.2"
+        "@tursodatabase/database-darwin-arm64": "0.4.0-pre.16",
+        "@tursodatabase/database-linux-arm64-gnu": "0.4.0-pre.16",
+        "@tursodatabase/database-linux-x64-gnu": "0.4.0-pre.16",
+        "@tursodatabase/database-win32-x64-msvc": "0.4.0-pre.16"
       }
     },
     "node_modules/@tursodatabase/database-common": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database-common/-/database-common-0.3.2.tgz",
-      "integrity": "sha512-CPkPuvDMUS6mKIdAwpCbfU7g6U81/mSfCcMDXZ6Bt1dA8DJyOgTZRf80MDaWTKLQ+0mjkmQ0cZPb9zD/R41Vkg==",
+      "version": "0.4.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@tursodatabase/database-common/-/database-common-0.4.0-pre.16.tgz",
+      "integrity": "sha512-Qp+eqz5fict0Tbx9MXYFtdZfaUk87HiO7ncTnKkG9YBLkYfgmbFfLmuI7FT2aMn6EGgQRyiHSD5fmvJ8LtgUhg==",
       "license": "MIT"
     },
     "node_modules/@tursodatabase/database-darwin-arm64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database-darwin-arm64/-/database-darwin-arm64-0.3.2.tgz",
-      "integrity": "sha512-oEYRWuYEXGsiiYk7WLBLNTOAES8Stuw0WguqPDcOgAab0H6CJHWcM2fIqjLE0VAtKm1kJ+m/qTonG+Ua4KMxSg==",
+      "version": "0.4.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@tursodatabase/database-darwin-arm64/-/database-darwin-arm64-0.4.0-pre.16.tgz",
+      "integrity": "sha512-clayNGr7exRCT3CQyBJn7ARghFCwkyJmtIV/zSmmy5IULOiXU8Y8bioptWzMNZpQXWVhWYPNSK/M4VxtGAN5zw==",
       "cpu": [
         "arm64"
       ],
@@ -824,9 +824,9 @@
       ]
     },
     "node_modules/@tursodatabase/database-linux-arm64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database-linux-arm64-gnu/-/database-linux-arm64-gnu-0.3.2.tgz",
-      "integrity": "sha512-F38fUQZtKtTFkdoMY2ciEoesiEHXkLHsqr6pWKUbmtOnldSHXirUem7o0F5BkjQPrcEYV96KLXTHP7v7o7Hesg==",
+      "version": "0.4.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@tursodatabase/database-linux-arm64-gnu/-/database-linux-arm64-gnu-0.4.0-pre.16.tgz",
+      "integrity": "sha512-dn1Syoe61/kIPojOY/KWN/I6el3zxEtCha0i7fefDMPUlWxmhKCDeP/pMAhyth/k80KufmAhWGB0A4RG2x00dQ==",
       "cpu": [
         "arm64"
       ],
@@ -837,9 +837,9 @@
       ]
     },
     "node_modules/@tursodatabase/database-linux-x64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database-linux-x64-gnu/-/database-linux-x64-gnu-0.3.2.tgz",
-      "integrity": "sha512-JI91AkdrlDMHBthZNMF4ADCMupjR3aboeeiokcz5PCwKklTBK84FHGJxKWa/ehu1hJ7CKXsp5cbpkLNIkAKcBg==",
+      "version": "0.4.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@tursodatabase/database-linux-x64-gnu/-/database-linux-x64-gnu-0.4.0-pre.16.tgz",
+      "integrity": "sha512-7GB26YvXrkvkJ7hrdVP7qhOmphoQ6/gJE2X0rbs+IJENadxdACXTqJHn1bt9PxB6+UC04foVcN841fN4jbhD/Q==",
       "cpu": [
         "x64"
       ],
@@ -850,9 +850,9 @@
       ]
     },
     "node_modules/@tursodatabase/database-win32-x64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database-win32-x64-msvc/-/database-win32-x64-msvc-0.3.2.tgz",
-      "integrity": "sha512-i3cPcH22R9twSrgVeQxs+9tG6nYfLebUkg+UIOkh4XYeZCmN9Nx24ddzKTx1IJ0vkm7sbpOg1hmPbwPlyfQbWA==",
+      "version": "0.4.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@tursodatabase/database-win32-x64-msvc/-/database-win32-x64-msvc-0.4.0-pre.16.tgz",
+      "integrity": "sha512-/lQeeOk47kt+iHSJjqulUEpr6zd5AwkvmR3UHFaDbbO/5r1Ji8yoz0AfHJ7R7iBdZnpWYCOSbh5gCJBmQTwzmw==",
       "cpu": [
         "x64"
       ],

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -35,7 +35,7 @@
     "vitest": "^4.0.1"
   },
   "dependencies": {
-    "@tursodatabase/database": "^0.3.2"
+    "@tursodatabase/database": "^0.4.0-pre.16"
   },
   "files": [
     "dist"


### PR DESCRIPTION
We introduced breaking change recently https://github.com/tursodatabase/turso/pull/4149 which makes DBs created before and after this change incompatible.

This PR updates everything to 0.4.0-pre.16 version which is used by python bindings added recently