### PR TITLE
Change default agentfs directory to ~/.agentfs/fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Initialize an agent filesystem:
 
 ```bash
 $ agentfs init my-agent
-Created agent filesystem: .agentfs/my-agent.db
+Created agent filesystem: ~/.agentfs/fs/my-agent.db
 Agent ID: my-agent
 ```
 
@@ -60,7 +60,7 @@ hello from agent
 You can also use a database path directly:
 
 ```bash
-$ agentfs fs cat .agentfs/my-agent.db hello.txt
+$ agentfs fs cat ~/.agentfs/fs/my-agent.db hello.txt
 hello from agent
 ```
 
@@ -102,7 +102,7 @@ import { AgentFS } from 'agentfs-sdk';
 
 // Persistent storage with identifier
 const agent = await AgentFS.open({ id: 'my-agent' });
-// Creates: .agentfs/my-agent.db
+// Creates: ~/.agentfs/fs/my-agent.db
 
 // Or use ephemeral in-memory database
 const ephemeralAgent = await AgentFS.open();

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "anyhow",
  "clap 4.5.53",
  "clap_complete",
- "dirs",
+ "dirs 6.0.0",
  "fuser",
  "libc",
  "parking_lot",
@@ -113,6 +113,7 @@ version = "0.3.0-pre.7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "dirs 5.0.1",
  "libc",
  "serde",
  "serde_json",
@@ -632,11 +633,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -647,7 +669,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1825,6 +1847,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/sandbox/Cargo.lock
+++ b/sandbox/Cargo.lock
@@ -92,6 +92,7 @@ version = "0.3.0-pre.7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "dirs",
  "libc",
  "serde",
  "serde_json",
@@ -499,6 +500,27 @@ dependencies = [
  "quote",
  "syn 2.0.111",
  "unicode-xid",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1119,6 +1141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1372,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -1600,6 +1638,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/sdk/python/agentfs_sdk/__init__.py
+++ b/sdk/python/agentfs_sdk/__init__.py
@@ -3,7 +3,7 @@
 A filesystem and key-value store for AI agents, powered by SQLite.
 """
 
-from .agentfs import AgentFS, AgentFSOptions
+from .agentfs import AgentFS, AgentFSOptions, agentfs_dir, local_agentfs_dir
 from .filesystem import Filesystem, Stats
 from .kvstore import KvStore
 from .toolcalls import ToolCall, ToolCalls, ToolCallStats
@@ -13,6 +13,8 @@ __version__ = "0.3.0-pre.7"
 __all__ = [
     "AgentFS",
     "AgentFSOptions",
+    "agentfs_dir",
+    "local_agentfs_dir",
     "KvStore",
     "Filesystem",
     "Stats",

--- a/sdk/python/agentfs_sdk/agentfs.py
+++ b/sdk/python/agentfs_sdk/agentfs.py
@@ -3,6 +3,7 @@
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from turso.aio import Connection, connect
@@ -12,13 +13,29 @@ from .kvstore import KvStore
 from .toolcalls import ToolCalls
 
 
+def agentfs_dir() -> Path:
+    """Global directory containing agentfs databases (~/.agentfs/fs)
+
+    This is the default location for new agent databases.
+    """
+    return Path.home() / ".agentfs" / "fs"
+
+
+def local_agentfs_dir() -> Path:
+    """Local directory containing agentfs databases (.agentfs in current directory)
+
+    This is checked first when resolving agent IDs for backward compatibility.
+    """
+    return Path(".agentfs")
+
+
 @dataclass
 class AgentFSOptions:
     """Configuration options for opening an AgentFS instance
 
     Attributes:
         id: Unique identifier for the agent.
-            - If provided without `path`: Creates storage at `.agentfs/{id}.db`
+            - If provided without `path`: Creates storage at `~/.agentfs/fs/{id}.db`
             - If provided with `path`: Uses the specified path
         path: Explicit path to the database file.
             - If provided: Uses the specified path directly
@@ -45,6 +62,50 @@ class AgentFS:
         self.tools = tools
 
     @staticmethod
+    def resolve(id_or_path: str) -> str:
+        """Resolve an id-or-path string to a database path
+
+        - Existing file path -> uses that path directly
+        - Otherwise -> treats as agent ID, looks for database in this order:
+          1. `.agentfs/{id}.db` (local directory)
+          2. `~/.agentfs/fs/{id}.db` (global directory)
+
+        Args:
+            id_or_path: Agent ID or path to database file
+
+        Returns:
+            Resolved database path
+
+        Raises:
+            ValueError: If the agent ID is invalid or the database doesn't exist
+        """
+        # Check if it's an existing file path
+        if os.path.exists(id_or_path):
+            return id_or_path
+
+        # Treat as an agent ID - validate for safety
+        if not re.match(r"^[a-zA-Z0-9_-]+$", id_or_path):
+            raise ValueError(
+                f"Invalid agent ID '{id_or_path}'. Agent IDs must contain only "
+                "alphanumeric characters, hyphens, and underscores."
+            )
+
+        # Check local directory first (.agentfs in current directory)
+        local_db_path = local_agentfs_dir() / f"{id_or_path}.db"
+        if local_db_path.exists():
+            return str(local_db_path)
+
+        # Then check global directory (~/.agentfs/fs)
+        global_db_path = agentfs_dir() / f"{id_or_path}.db"
+        if global_db_path.exists():
+            return str(global_db_path)
+
+        raise ValueError(
+            f"Agent '{id_or_path}' not found in local (.agentfs) or "
+            "global (~/.agentfs/fs) directories"
+        )
+
+    @staticmethod
     async def open(options: AgentFSOptions) -> "AgentFS":
         """Open an agent filesystem
 
@@ -58,7 +119,7 @@ class AgentFS:
             ValueError: If neither id nor path is provided, or if id contains invalid characters
 
         Example:
-            >>> # Using id (creates .agentfs/my-agent.db)
+            >>> # Using id (creates ~/.agentfs/fs/my-agent.db)
             >>> agent = await AgentFS.open(AgentFSOptions(id='my-agent'))
             >>>
             >>> # Using id with custom path
@@ -82,10 +143,9 @@ class AgentFS:
             db_path = options.path
         else:
             # id is guaranteed to be defined here (we checked not id and not path above)
-            directory = ".agentfs"
-            if not os.path.exists(directory):
-                os.makedirs(directory, exist_ok=True)
-            db_path = f"{directory}/{options.id}.db"
+            directory = agentfs_dir()
+            directory.mkdir(parents=True, exist_ok=True)
+            db_path = str(directory / f"{options.id}.db")
 
         # Connect to the database to ensure it's created
         db = await connect(db_path)

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -53,6 +53,7 @@ version = "0.3.0-pre.7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "dirs",
  "libc",
  "serde",
  "serde_json",
@@ -292,6 +293,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -654,6 +676,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +810,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pack1"
@@ -957,6 +995,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1664,11 +1713,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1682,20 +1740,41 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1705,9 +1784,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1723,9 +1814,21 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1735,9 +1838,21 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0"
 libc = "0.2"
 anyhow = "1.0"
 thiserror = "1.0"
+dirs = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,8 +1,26 @@
 import { Database } from '@tursodatabase/database';
 import { existsSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 import { KvStore } from './kvstore';
 import { Filesystem } from './filesystem';
 import { ToolCalls } from './toolcalls';
+
+/**
+ * Global directory containing agentfs databases (~/.agentfs/fs)
+ * This is the default location for new agent databases.
+ */
+export function agentfsDir(): string {
+  return join(homedir(), '.agentfs', 'fs');
+}
+
+/**
+ * Local directory containing agentfs databases (.agentfs in current directory)
+ * This is checked first when resolving agent IDs for backward compatibility.
+ */
+export function localAgentfsDir(): string {
+  return '.agentfs';
+}
 
 /**
  * Configuration options for opening an AgentFS instance
@@ -10,7 +28,7 @@ import { ToolCalls } from './toolcalls';
 export interface AgentFSOptions {
   /**
    * Unique identifier for the agent.
-   * - If provided without `path`: Creates storage at `.agentfs/{id}.db`
+   * - If provided without `path`: Creates storage at `~/.agentfs/fs/{id}.db`
    * - If provided with `path`: Uses the specified path
    */
   id?: string;
@@ -40,12 +58,54 @@ export class AgentFS {
   }
 
   /**
+   * Resolve an id-or-path string to a database path
+   *
+   * - Existing file path -> uses that path directly
+   * - Otherwise -> treats as agent ID, looks for database in this order:
+   *   1. `.agentfs/{id}.db` (local directory)
+   *   2. `~/.agentfs/fs/{id}.db` (global directory)
+   *
+   * @param idOrPath Agent ID or path to database file
+   * @returns Resolved database path
+   * @throws Error if the agent ID is invalid or the database doesn't exist
+   */
+  static resolve(idOrPath: string): string {
+    // Check if it's an existing file path
+    if (existsSync(idOrPath)) {
+      return idOrPath;
+    }
+
+    // Treat as an agent ID - validate for safety
+    if (!/^[a-zA-Z0-9_-]+$/.test(idOrPath)) {
+      throw new Error(
+        `Invalid agent ID '${idOrPath}'. Agent IDs must contain only alphanumeric characters, hyphens, and underscores.`
+      );
+    }
+
+    // Check local directory first (.agentfs in current directory)
+    const localDbPath = join(localAgentfsDir(), `${idOrPath}.db`);
+    if (existsSync(localDbPath)) {
+      return localDbPath;
+    }
+
+    // Then check global directory (~/.agentfs/fs)
+    const globalDbPath = join(agentfsDir(), `${idOrPath}.db`);
+    if (existsSync(globalDbPath)) {
+      return globalDbPath;
+    }
+
+    throw new Error(
+      `Agent '${idOrPath}' not found in local (.agentfs) or global (~/.agentfs/fs) directories`
+    );
+  }
+
+  /**
    * Open an agent filesystem
    * @param options Configuration options (id and/or path required)
    * @returns Fully initialized AgentFS instance
    * @example
    * ```typescript
-   * // Using id (creates .agentfs/my-agent.db)
+   * // Using id (creates ~/.agentfs/fs/my-agent.db)
    * const agent = await AgentFS.open({ id: 'my-agent' });
    *
    * // Using id with custom path
@@ -76,11 +136,11 @@ export class AgentFS {
       dbPath = path;
     } else {
       // id is guaranteed to be defined here (we checked !id && !path above)
-      const dir = '.agentfs';
+      const dir = agentfsDir();
       if (!existsSync(dir)) {
         mkdirSync(dir, { recursive: true });
       }
-      dbPath = `${dir}/${id}.db`;
+      dbPath = join(dir, `${id}.db`);
     }
 
     const db = new Database(dbPath);

--- a/sdk/typescript/tests/index.test.ts
+++ b/sdk/typescript/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { AgentFS } from "../src/index";
+import { AgentFS, agentfsDir } from "../src/index";
 import { existsSync, rmSync } from "fs";
+import { join } from "path";
 
 describe("AgentFS Integration Tests", () => {
   let agent: AgentFS;
@@ -52,9 +53,9 @@ describe("AgentFS Integration Tests", () => {
   });
 
   describe("Database Persistence", () => {
-    it("should persist database file to .agentfs directory", async () => {
-      // Check that database file exists in .agentfs directory
-      const dbPath = `.agentfs/${testId}.db`;
+    it("should persist database file to global ~/.agentfs/fs directory", async () => {
+      // Check that database file exists in global ~/.agentfs/fs directory
+      const dbPath = join(agentfsDir(), `${testId}.db`);
       expect(existsSync(dbPath)).toBe(true);
     });
 
@@ -86,7 +87,7 @@ describe("AgentFS Integration Tests", () => {
  * @param id The agent ID to clean up
  */
 function cleanupAgentFiles(id: string): void {
-  const dbPath = `.agentfs/${id}.db`;
+  const dbPath = join(agentfsDir(), `${id}.db`);
   try {
     // Remove database file and SQLite WAL files
     [dbPath, `${dbPath}-shm`, `${dbPath}-wal`].forEach((file) => {


### PR DESCRIPTION
The init command now creates databases in the global ~/.agentfs/fs directory instead of the local .agentfs directory. Commands that resolve agent IDs first check the local directory for backward compatibility, then fall back to the global directory.

This is useful when creating an overlay of a source directory, for example, to avoid putting the agentfs filesystem in the same base directory.