### PR TITLE
Add readdir_plus optimization to eliminate N+1 queries

### DIFF
--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -98,6 +98,15 @@ pub struct FilesystemStats {
     pub bytes_used: u64,
 }
 
+/// Directory entry with full statistics
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    /// Entry name (without path)
+    pub name: String,
+    /// Full statistics for this entry
+    pub stats: Stats,
+}
+
 impl Stats {
     pub fn is_file(&self) -> bool {
         (self.mode & S_IFMT) == S_IFREG
@@ -147,6 +156,14 @@ pub trait FileSystem: Send + Sync {
     ///
     /// Returns `Ok(None)` if the directory does not exist.
     async fn readdir(&self, path: &str) -> Result<Option<Vec<String>>>;
+
+    /// List directory contents with full statistics for each entry
+    ///
+    /// This is an optimized version of readdir that returns both entry names
+    /// and their statistics in a single call, avoiding N+1 queries.
+    ///
+    /// Returns `Ok(None)` if the directory does not exist.
+    async fn readdir_plus(&self, path: &str) -> Result<Option<Vec<DirEntry>>>;
 
     /// Create a directory
     async fn mkdir(&self, path: &str) -> Result<()>;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -14,8 +14,8 @@ use turso::{Builder, Connection, Value};
 #[cfg(unix)]
 pub use filesystem::HostFS;
 pub use filesystem::{
-    FileSystem, FilesystemStats, FsError, OverlayFS, Stats, DEFAULT_DIR_MODE, DEFAULT_FILE_MODE,
-    S_IFDIR, S_IFLNK, S_IFMT, S_IFREG,
+    DirEntry, FileSystem, FilesystemStats, FsError, OverlayFS, Stats, DEFAULT_DIR_MODE,
+    DEFAULT_FILE_MODE, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG,
 };
 pub use kvstore::KvStore;
 pub use toolcalls::{ToolCall, ToolCallStats, ToolCallStatus, ToolCalls};


### PR DESCRIPTION
Implement readdir_plus() across the FileSystem trait which returns directory entries with their stats in a single call. This eliminates the N+1 query problem where readdir() returned names and then stat() was called for each entry.