### PR TITLE
python-sdk: add Python 3.10+ support

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "agentfs-sdk"
 version = "0.4.0-pre.2"
 description = "AgentFS Python SDK - A filesystem and key-value store for AI agents"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 keywords = ["ai", "agent", "turso", "sqlite", "key-value", "filesystem"]
 authors = [
@@ -21,6 +21,8 @@ classifiers = [
     'Operating System :: Microsoft :: Windows',
     'Operating System :: MacOS',
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -48,7 +50,7 @@ include = ["agentfs_sdk*"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]


### PR DESCRIPTION
## Summary

Add support for Python 3.10+ in the Python SDK.

Closes #117

## Changes

- Update `requires-python` from `>=3.12` to `>=3.10`
- Add Python 3.10 and 3.11 classifiers
- Update ruff `target-version` to `py310`

## Analysis

The SDK codebase is fully compatible with Python 3.10+ as it only uses:
- Standard library modules (`datetime`, `pathlib`, `json`, `typing`, `dataclasses`)
- Type hints with union syntax (`X | None`) - available since Python 3.10 (PEP 604)
- No Python 3.12-specific features

## Impact

This change enables:
1. Python 3.10 and 3.11 users to install the SDK
2. Support for LTS Python versions commonly used in production
3. Broader adoption without any code changes

## Test Plan

- [ ] Verify SDK installs on Python 3.10
- [ ] Verify SDK installs on Python 3.11
- [ ] Run existing tests on Python 3.10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)