### PR TITLE
Feature: Add Snapshot functionality to Rust SDK and CLI

### DIFF
--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -102,6 +102,16 @@ impl AgentFSOptions {
             })?))
         }
     }
+
+    pub fn opts_to_db_path(opts: AgentFSOptions) -> Result<String> {
+        if let Some(path) = opts.path {
+            Ok(path)
+        } else if let Some(id) = opts.id {
+            Ok(format!("{}/{}.db", agentfs_dir().display(), id))
+        } else {
+            Ok(":memory:".to_string())
+        }
+    }
 }
 
 /// The main AgentFS SDK struct


### PR DESCRIPTION
Closes #57 
Closes #61

Implements consistent point-in-time snapshot API in the rust SDK

- discovers and creates tables and indexes from sqlite_schema
- clones data for each table
- fsync is switched off for faster writes