### PR TITLE
fuse: Don't expire directory entries in the kernel

### DIFF
--- a/cli/src/fuse.rs
+++ b/cli/src/fuse.rs
@@ -17,7 +17,9 @@ use std::{
 };
 use tokio::runtime::Runtime;
 
-const TTL: Duration = Duration::from_secs(1);
+/// Cache entries never expire - we explicitly invalidate on mutations.
+/// This is safe because we are the only writer to the filesystem.
+const TTL: Duration = Duration::MAX;
 
 /// Options for mounting an agent filesystem via FUSE.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Since AgentFS is the only writer to the SQLite-backed filesystem, the kernel can cache metadata and directory entries indefinitely. When the kernel initiates operations (create, unlink, rename, etc.), it already knows about the changes and updates its cache from our replies - no explicit invalidation is needed.