### PR TITLE
sdk/rust: Fix pwrite to flushing buffer before returning

### DIFF
--- a/sdk/rust/src/filesystem/hostfs.rs
+++ b/sdk/rust/src/filesystem/hostfs.rs
@@ -131,6 +131,7 @@ impl FileSystem for HostFS {
 
         file.seek(std::io::SeekFrom::Start(offset)).await?;
         file.write_all(data).await?;
+        file.flush().await?;
         Ok(())
     }
 


### PR DESCRIPTION
Let's call flush() after write_all() to be safe. It's unclear to me if this explains a hostfs test failure I saw, but Tokio's documentation suggests that a write_all() returns when the write is handed over to the thread pool, but makes no guarantees that the write actually is done, meaning a subsequent read might return state data.