### PR TITLE
Add --version flag using git tags

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 fn main() {
     // Sandbox uses libunwind-ptrace which depends on liblzma and gcc_s.
     // Only available on Linux x86_64.
@@ -15,4 +17,25 @@ fn main() {
         println!("cargo:rustc-link-search=/usr/local/lib");
         println!("cargo:rustc-link-search=/Library/Frameworks/macFUSE.framework/Versions/A");
     }
+
+    // Capture git version from tags for --version flag
+    // Rerun if git HEAD changes (new commits or tags)
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/tags");
+
+    let version = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|v| v.trim().to_string())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    println!("cargo:rustc-env=AGENTFS_VERSION={}", version);
 }

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
 #[command(name = "agentfs")]
+#[command(version = env!("AGENTFS_VERSION"))]
 #[command(about = "The filesystem for agents", long_about = None)]
 pub struct Args {
     #[command(subcommand)]


### PR DESCRIPTION
Use build.rs to capture the version from `git describe --tags` at compile time, falling back to CARGO_PKG_VERSION if git is unavailable. This enables `agentfs --version` to show the git tag, commit count, and hash.