### PR TITLE
Add NFS-based `agentfs run` support for macOS

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -77,11 +77,13 @@ dependencies = [
  "agentfs-sandbox",
  "agentfs-sdk",
  "anyhow",
+ "async-trait",
  "clap 4.5.53",
  "clap_complete",
  "dirs",
  "fuser",
  "libc",
+ "nfsserve",
  "parking_lot",
  "reverie",
  "reverie-process",
@@ -89,6 +91,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
  "turso",
  "uuid",
 ]
@@ -320,6 +323,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestream"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f720842a717d6afaf69fee2dc69b771edc165f12cc3eb1b0e8eeef53a86454"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -698,6 +710,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1310,6 +1334,7 @@ checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+ "redox_syscall 0.6.0",
 ]
 
 [[package]]
@@ -1464,6 +1489,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
+name = "nfsserve"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73615e054238e6bf5e554407b5b23e82fc63616db459057c51b794799eda6fb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "byteorder",
+ "bytestream",
+ "filetime",
+ "futures 0.3.31",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "tracing-attributes",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1547,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-traits"
@@ -1602,7 +1658,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1826,6 +1882,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
 dependencies = [
  "bitflags 2.10.0",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,12 +28,17 @@ libc = "0.2"
 fuser = { version = "0.15", default-features = false, features = ["abi-7-23"] }
 uuid = { version = "1", features = ["v4"] }
 
-# macOS dependencies for FUSE functionality (requires macFUSE)
+# macOS dependencies for FUSE and NFS functionality
 [target.'cfg(target_os = "macos")'.dependencies]
 fuser = { version = "0.15", default-features = false, features = [
     "abi-7-23",
     "libfuse",
 ] }
+# NFS server for userspace filesystem without FUSE (used by `agentfs run`)
+nfsserve = "0.10"
+uuid = { version = "1", features = ["v4"] }
+async-trait = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Ensure transitive `aegis` (pulled in by `turso`) builds on macOS arm64 by
 # forcing the `pure-rust` feature, which skips the C/NEON backend that fails
 # with Apple clang (`veor3q_u8` in `aegis128l_neon_sha3.c`).

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -8,9 +8,19 @@ mod mount;
 #[path = "mount_stub.rs"]
 mod mount;
 
+// Run module selection:
+// - Linux x86_64: use overlay sandbox (run.rs)
+// - macOS: use NFS-based sandbox (run_nfs.rs)
+// - Other platforms: use stub (run_stub.rs)
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod run;
-#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+
+#[cfg(target_os = "macos")]
+#[path = "run_nfs.rs"]
+mod run;
+
+#[cfg(not(any(all(target_os = "linux", target_arch = "x86_64"), target_os = "macos")))]
 #[path = "run_stub.rs"]
 mod run;
 

--- a/cli/src/cmd/run_nfs.rs
+++ b/cli/src/cmd/run_nfs.rs
@@ -1,0 +1,247 @@
+//! NFS-based run command for macOS.
+//!
+//! This module provides a sandboxed execution environment using NFS for
+//! filesystem mounting on macOS. The current working directory becomes a
+//! copy-on-write overlay backed by AgentFS, mounted via a localhost NFS server.
+//!
+//! This approach works without requiring macFUSE or FSKit system extensions.
+
+#![cfg(target_os = "macos")]
+
+use agentfs_sdk::{AgentFS, AgentFSOptions, FileSystem, HostFS, OverlayFS};
+use anyhow::{Context, Result};
+use nfsserve::tcp::NFSTcp;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::nfs::AgentNFS;
+
+/// Default NFS port to try (use a high port to avoid needing root)
+const DEFAULT_NFS_PORT: u32 = 11111;
+
+/// Handle the `run` command using NFS on macOS.
+pub async fn handle_run_command(
+    _allow: Vec<PathBuf>,
+    _no_default_allows: bool,
+    _experimental_sandbox: bool,
+    _strace: bool,
+    command: PathBuf,
+    args: Vec<String>,
+) -> Result<()> {
+    let cwd = std::env::current_dir().context("Failed to get current directory")?;
+
+    let session = setup_run_directory()?;
+
+    // Initialize the AgentFS database
+    let db_path_str = session
+        .db_path
+        .to_str()
+        .context("Database path contains non-UTF8 characters")?;
+
+    let agentfs = AgentFS::open(AgentFSOptions::with_path(db_path_str))
+        .await
+        .context("Failed to create AgentFS")?;
+
+    // Create overlay filesystem with cwd as base
+    let cwd_str = cwd.to_string_lossy().to_string();
+    let hostfs = HostFS::new(&cwd_str).context("Failed to create HostFS")?;
+    let overlay = OverlayFS::new(Arc::new(hostfs), agentfs.fs);
+
+    // Initialize the overlay (copies directory structure)
+    overlay
+        .init(&cwd_str)
+        .await
+        .context("Failed to initialize overlay")?;
+
+    let fs: Arc<Mutex<dyn FileSystem>> = Arc::new(Mutex::new(overlay));
+
+    // Get current user/group
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+
+    // Create NFS adapter
+    let nfs = AgentNFS::new(fs, uid, gid);
+
+    // Find an available port
+    let port = find_available_port(DEFAULT_NFS_PORT)?;
+
+    // Start NFS server in background
+    let listener = nfsserve::tcp::NFSTcpListener::bind(&format!("127.0.0.1:{}", port), nfs)
+        .await
+        .context("Failed to bind NFS server")?;
+
+    // Spawn the NFS server task
+    let server_handle = tokio::spawn(async move {
+        if let Err(e) = listener.handle_forever().await {
+            eprintln!("NFS server error: {}", e);
+        }
+    });
+
+    // Give the server a moment to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Mount the NFS filesystem
+    mount_nfs(port, &session.mountpoint)?;
+
+    print_welcome_banner(&session.mountpoint);
+
+    // Run the command
+    let exit_code = run_command_in_mount(&session.mountpoint, &session.run_dir, command, args)?;
+
+    // Unmount
+    unmount(&session.mountpoint)?;
+
+    // Stop the server
+    server_handle.abort();
+
+    // Clean up mountpoint directory (but keep the delta database)
+    if let Err(e) = std::fs::remove_dir(&session.mountpoint) {
+        eprintln!(
+            "Warning: Failed to clean up mountpoint {}: {}",
+            session.mountpoint.display(),
+            e
+        );
+    }
+
+    // Print the location of the delta layer for the user
+    eprintln!();
+    eprintln!("Delta layer saved to: {}", session.db_path.display());
+    eprintln!();
+    eprintln!("To see what changed:");
+    eprintln!("  agentfs diff {}", session.db_path.display());
+
+    std::process::exit(exit_code);
+}
+
+/// Print the welcome banner showing sandbox configuration.
+fn print_welcome_banner(cwd: &Path) {
+    eprintln!("Welcome to AgentFS!");
+    eprintln!();
+    eprintln!("  {} (copy-on-write)", cwd.display());
+    eprintln!("  ⚠️  Everything else is WRITABLE.");
+    eprintln!();
+}
+
+/// Configuration for a sandbox run session.
+struct RunSession {
+    /// Directory containing session artifacts.
+    run_dir: PathBuf,
+    /// Path to the delta database.
+    db_path: PathBuf,
+    /// Path where NFS filesystem will be mounted.
+    mountpoint: PathBuf,
+}
+
+/// Create a unique run directory with database and mountpoint paths.
+fn setup_run_directory() -> Result<RunSession> {
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let home_dir = dirs::home_dir().context("Failed to get home directory")?;
+    let run_dir = home_dir.join(".agentfs").join("run").join(&run_id);
+    std::fs::create_dir_all(&run_dir).context("Failed to create run directory")?;
+
+    let db_path = run_dir.join("delta.db");
+    let mountpoint = run_dir.join("mnt");
+    std::fs::create_dir_all(&mountpoint).context("Failed to create mountpoint")?;
+
+    // Create zsh config directory with custom prompt
+    let zsh_dir = run_dir.join("zsh");
+    std::fs::create_dir_all(&zsh_dir).context("Failed to create zsh config directory")?;
+    std::fs::write(zsh_dir.join(".zshrc"), "PROMPT='🤖 %n@%m:%~%# '\n")
+        .context("Failed to write zsh config")?;
+
+    Ok(RunSession {
+        run_dir,
+        db_path,
+        mountpoint,
+    })
+}
+
+/// Find an available TCP port starting from the given port.
+fn find_available_port(start_port: u32) -> Result<u32> {
+    for port in start_port..start_port + 100 {
+        if std::net::TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok() {
+            return Ok(port);
+        }
+    }
+    anyhow::bail!(
+        "Could not find an available port in range {}-{}",
+        start_port,
+        start_port + 100
+    );
+}
+
+/// Mount the NFS filesystem.
+fn mount_nfs(port: u32, mountpoint: &Path) -> Result<()> {
+    // macOS mount_nfs syntax
+    let output = Command::new("/sbin/mount_nfs")
+        .args([
+            "-o",
+            &format!(
+                "nolocks,vers=3,tcp,port={},mountport={},soft,timeo=10,retrans=2",
+                port, port
+            ),
+            &format!("127.0.0.1:/"),
+            mountpoint.to_str().unwrap(),
+        ])
+        .output()
+        .context("Failed to execute mount_nfs")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to mount NFS: {}", stderr.trim());
+    }
+
+    Ok(())
+}
+
+/// Run a command with the working directory set to the mounted filesystem.
+fn run_command_in_mount(
+    mountpoint: &Path,
+    run_dir: &Path,
+    command: PathBuf,
+    args: Vec<String>,
+) -> Result<i32> {
+    let mut cmd = Command::new(&command);
+    cmd.args(&args)
+        .current_dir(mountpoint)
+        .env("AGENTFS", "1")
+        // Bash prompt
+        .env("PS1", "🤖 \\u@\\h:\\w\\$ ")
+        // Zsh: use custom ZDOTDIR to override prompt
+        .env("ZDOTDIR", run_dir.join("zsh"));
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Failed to execute command: {}", command.display()))?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Unmount the NFS filesystem.
+fn unmount(mountpoint: &Path) -> Result<()> {
+    let output = Command::new("/sbin/umount")
+        .arg(mountpoint)
+        .output()
+        .context("Failed to execute umount")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Try force unmount
+        let output2 = Command::new("/sbin/umount")
+            .arg("-f")
+            .arg(mountpoint)
+            .output()?;
+
+        if !output2.status.success() {
+            anyhow::bail!(
+                "Failed to unmount: {}. You may need to manually unmount with: umount -f {}",
+                stderr.trim(),
+                mountpoint.display()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,9 @@ mod daemon;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod fuse;
 
+#[cfg(target_os = "macos")]
+mod nfs;
+
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 

--- a/cli/src/nfs.rs
+++ b/cli/src/nfs.rs
@@ -1,0 +1,491 @@
+//! NFS server adapter for AgentFS.
+//!
+//! This module implements nfsserve's NFSFileSystem trait on top of AgentFS's
+//! FileSystem trait, enabling macOS to mount AgentFS via NFS without requiring
+//! macFUSE or FSKit system extensions.
+
+#![cfg(target_os = "macos")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use agentfs_sdk::{FileSystem, Stats, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
+use async_trait::async_trait;
+use nfsserve::nfs::{
+    fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, nfstime3, sattr3, specdata3,
+};
+use nfsserve::vfs::{DirEntry, NFSFileSystem, ReadDirResult, VFSCapabilities};
+use tokio::sync::{Mutex, RwLock};
+
+/// Root directory inode number
+const ROOT_INO: fileid3 = 1;
+
+/// NFS adapter that wraps an AgentFS FileSystem.
+pub struct AgentNFS {
+    /// The underlying filesystem (wrapped in Mutex to serialize operations)
+    fs: Arc<Mutex<dyn FileSystem>>,
+    /// Inode-to-path mapping (async RwLock for use in async methods)
+    inode_map: RwLock<InodeMap>,
+    /// User ID for all files
+    uid: u32,
+    /// Group ID for all files
+    gid: u32,
+}
+
+/// Bidirectional mapping between inodes and paths.
+struct InodeMap {
+    /// Path to inode
+    path_to_ino: HashMap<String, fileid3>,
+    /// Inode to path
+    ino_to_path: HashMap<fileid3, String>,
+    /// Next available inode number
+    next_ino: fileid3,
+}
+
+impl InodeMap {
+    fn new() -> Self {
+        let mut map = InodeMap {
+            path_to_ino: HashMap::new(),
+            ino_to_path: HashMap::new(),
+            next_ino: ROOT_INO + 1,
+        };
+        // Root directory is always inode 1
+        map.path_to_ino.insert("/".to_string(), ROOT_INO);
+        map.ino_to_path.insert(ROOT_INO, "/".to_string());
+        map
+    }
+
+    fn get_or_create_ino(&mut self, path: &str) -> fileid3 {
+        if let Some(&ino) = self.path_to_ino.get(path) {
+            return ino;
+        }
+        let ino = self.next_ino;
+        self.next_ino += 1;
+        self.path_to_ino.insert(path.to_string(), ino);
+        self.ino_to_path.insert(ino, path.to_string());
+        ino
+    }
+
+    fn get_path(&self, ino: fileid3) -> Option<String> {
+        self.ino_to_path.get(&ino).cloned()
+    }
+
+    fn remove_path(&mut self, path: &str) {
+        if let Some(ino) = self.path_to_ino.remove(path) {
+            self.ino_to_path.remove(&ino);
+        }
+    }
+
+    fn rename_path(&mut self, from: &str, to: &str) {
+        if let Some(ino) = self.path_to_ino.remove(from) {
+            self.ino_to_path.insert(ino, to.to_string());
+            self.path_to_ino.insert(to.to_string(), ino);
+        }
+    }
+}
+
+impl AgentNFS {
+    /// Create a new NFS adapter wrapping the given filesystem.
+    pub fn new(fs: Arc<Mutex<dyn FileSystem>>, uid: u32, gid: u32) -> Self {
+        AgentNFS {
+            fs,
+            inode_map: RwLock::new(InodeMap::new()),
+            uid,
+            gid,
+        }
+    }
+
+    /// Convert AgentFS Stats to NFS fattr3.
+    fn stats_to_fattr(&self, stats: &Stats, ino: fileid3) -> fattr3 {
+        let ftype = match stats.mode & S_IFMT {
+            S_IFREG => ftype3::NF3REG,
+            S_IFDIR => ftype3::NF3DIR,
+            S_IFLNK => ftype3::NF3LNK,
+            _ => ftype3::NF3REG,
+        };
+
+        fattr3 {
+            ftype,
+            mode: stats.mode & 0o7777,
+            nlink: stats.nlink,
+            uid: self.uid,
+            gid: self.gid,
+            size: stats.size as u64,
+            used: stats.size as u64,
+            rdev: specdata3::default(),
+            fsid: 0,
+            fileid: ino,
+            atime: nfstime3 {
+                seconds: stats.atime as u32,
+                nseconds: 0,
+            },
+            mtime: nfstime3 {
+                seconds: stats.mtime as u32,
+                nseconds: 0,
+            },
+            ctime: nfstime3 {
+                seconds: stats.ctime as u32,
+                nseconds: 0,
+            },
+        }
+    }
+
+    /// Get path for an inode, returning NOENT error if not found.
+    async fn get_path(&self, ino: fileid3) -> Result<String, nfsstat3> {
+        self.inode_map
+            .read()
+            .await
+            .get_path(ino)
+            .ok_or(nfsstat3::NFS3ERR_NOENT)
+    }
+
+    /// Join parent path and filename into a full path.
+    fn join_path(parent: &str, name: &str) -> String {
+        if parent == "/" {
+            format!("/{}", name)
+        } else {
+            format!("{}/{}", parent, name)
+        }
+    }
+}
+
+#[async_trait]
+impl NFSFileSystem for AgentNFS {
+    fn root_dir(&self) -> fileid3 {
+        ROOT_INO
+    }
+
+    fn capabilities(&self) -> VFSCapabilities {
+        VFSCapabilities::ReadWrite
+    }
+
+    async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+
+        // Handle . and ..
+        if name == "." {
+            return Ok(dirid);
+        }
+        if name == ".." {
+            let parent_path = if dir_path == "/" {
+                "/".to_string()
+            } else {
+                std::path::Path::new(&dir_path)
+                    .parent()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "/".to_string())
+            };
+            let parent_path = if parent_path.is_empty() {
+                "/".to_string()
+            } else {
+                parent_path
+            };
+            return Ok(self.inode_map.write().await.get_or_create_ino(&parent_path));
+        }
+
+        let full_path = Self::join_path(&dir_path, name);
+
+        // Lock filesystem for the duration of these operations
+        let fs = self.fs.lock().await;
+
+        // Check if path exists
+        let stats = fs
+            .lstat(&full_path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .ok_or(nfsstat3::NFS3ERR_NOENT)?;
+
+        // Verify parent is a directory
+        let dir_stats = fs
+            .lstat(&dir_path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .ok_or(nfsstat3::NFS3ERR_NOENT)?;
+
+        drop(fs); // Release lock before acquiring inode_map lock
+
+        if !dir_stats.is_directory() {
+            return Err(nfsstat3::NFS3ERR_NOTDIR);
+        }
+
+        let _ = stats; // We just needed to verify it exists
+        Ok(self.inode_map.write().await.get_or_create_ino(&full_path))
+    }
+
+    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+        let path = self.get_path(id).await?;
+        let fs = self.fs.lock().await;
+        let stats = fs
+            .lstat(&path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .ok_or(nfsstat3::NFS3ERR_NOENT)?;
+
+        Ok(self.stats_to_fattr(&stats, id))
+    }
+
+    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+        let path = self.get_path(id).await?;
+
+        // Handle size change (truncate)
+        if let nfsserve::nfs::set_size3::size(size) = setattr.size {
+            let fs = self.fs.lock().await;
+            fs.truncate(&path, size)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        // Return updated attributes
+        self.getattr(id).await
+    }
+
+    async fn read(
+        &self,
+        id: fileid3,
+        offset: u64,
+        count: u32,
+    ) -> Result<(Vec<u8>, bool), nfsstat3> {
+        let path = self.get_path(id).await?;
+        let fs = self.fs.lock().await;
+
+        let data = fs
+            .pread(&path, offset, count as u64)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .ok_or(nfsstat3::NFS3ERR_NOENT)?;
+
+        // Check if we've reached EOF
+        let stats = fs
+            .lstat(&path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .ok_or(nfsstat3::NFS3ERR_NOENT)?;
+
+        let eof = offset + data.len() as u64 >= stats.size as u64;
+        Ok((data, eof))
+    }
+
+    async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+        let path = self.get_path(id).await?;
+
+        {
+            let fs = self.fs.lock().await;
+            fs.pwrite(&path, offset, data)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        self.getattr(id).await
+    }
+
+    async fn create(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+        _attr: sattr3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let full_path = Self::join_path(&dir_path, name);
+
+        // Create empty file
+        {
+            let fs = self.fs.lock().await;
+            fs.write_file(&full_path, &[])
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        let ino = self.inode_map.write().await.get_or_create_ino(&full_path);
+        let attr = self.getattr(ino).await?;
+        Ok((ino, attr))
+    }
+
+    async fn create_exclusive(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+    ) -> Result<fileid3, nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let full_path = Self::join_path(&dir_path, name);
+
+        let fs = self.fs.lock().await;
+
+        // Check if file already exists
+        if fs
+            .lstat(&full_path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .is_some()
+        {
+            return Err(nfsstat3::NFS3ERR_EXIST);
+        }
+
+        // Create empty file
+        fs.write_file(&full_path, &[])
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+
+        drop(fs);
+        Ok(self.inode_map.write().await.get_or_create_ino(&full_path))
+    }
+
+    async fn mkdir(
+        &self,
+        dirid: fileid3,
+        dirname: &filename3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+        let name = std::str::from_utf8(dirname).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let full_path = Self::join_path(&dir_path, name);
+
+        {
+            let fs = self.fs.lock().await;
+            fs.mkdir(&full_path)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        let ino = self.inode_map.write().await.get_or_create_ino(&full_path);
+        let attr = self.getattr(ino).await?;
+        Ok((ino, attr))
+    }
+
+    async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let full_path = Self::join_path(&dir_path, name);
+
+        {
+            let fs = self.fs.lock().await;
+            fs.remove(&full_path)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        self.inode_map.write().await.remove_path(&full_path);
+        Ok(())
+    }
+
+    async fn rename(
+        &self,
+        from_dirid: fileid3,
+        from_filename: &filename3,
+        to_dirid: fileid3,
+        to_filename: &filename3,
+    ) -> Result<(), nfsstat3> {
+        let from_dir = self.get_path(from_dirid).await?;
+        let to_dir = self.get_path(to_dirid).await?;
+        let from_name = std::str::from_utf8(from_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let to_name = std::str::from_utf8(to_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+
+        let from_path = Self::join_path(&from_dir, from_name);
+        let to_path = Self::join_path(&to_dir, to_name);
+
+        {
+            let fs = self.fs.lock().await;
+            fs.rename(&from_path, &to_path)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        self.inode_map
+            .write()
+            .await
+            .rename_path(&from_path, &to_path);
+        Ok(())
+    }
+
+    async fn readdir(
+        &self,
+        dirid: fileid3,
+        start_after: fileid3,
+        max_entries: usize,
+    ) -> Result<ReadDirResult, nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+
+        let entries = {
+            let fs = self.fs.lock().await;
+            fs.readdir_plus(&dir_path)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?
+                .ok_or(nfsstat3::NFS3ERR_NOENT)?
+        };
+
+        let mut result = ReadDirResult {
+            entries: Vec::new(),
+            end: false,
+        };
+
+        // Find start position if start_after is specified
+        let mut skip = start_after > 0;
+        let mut skipped_count = 0;
+
+        for entry in &entries {
+            let entry_path = Self::join_path(&dir_path, &entry.name);
+            let ino = self.inode_map.write().await.get_or_create_ino(&entry_path);
+
+            if skip {
+                if ino == start_after {
+                    skip = false;
+                }
+                skipped_count += 1;
+                continue;
+            }
+
+            if result.entries.len() >= max_entries {
+                break;
+            }
+
+            result.entries.push(DirEntry {
+                fileid: ino,
+                name: entry.name.as_bytes().into(),
+                attr: self.stats_to_fattr(&entry.stats, ino),
+            });
+        }
+
+        // Mark as end if we've returned all remaining entries
+        result.end = result.entries.len() + skipped_count >= entries.len();
+
+        Ok(result)
+    }
+
+    async fn symlink(
+        &self,
+        dirid: fileid3,
+        linkname: &filename3,
+        symlink: &nfspath3,
+        _attr: &sattr3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let dir_path = self.get_path(dirid).await?;
+        let name = std::str::from_utf8(linkname).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let target = std::str::from_utf8(symlink).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let full_path = Self::join_path(&dir_path, name);
+
+        {
+            let fs = self.fs.lock().await;
+            fs.symlink(target, &full_path)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+
+        let ino = self.inode_map.write().await.get_or_create_ino(&full_path);
+        let attr = self.getattr(ino).await?;
+        Ok((ino, attr))
+    }
+
+    async fn readlink(&self, id: fileid3) -> Result<nfspath3, nfsstat3> {
+        let path = self.get_path(id).await?;
+
+        let fs = self.fs.lock().await;
+        let target = fs
+            .readlink(&path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?
+            .ok_or(nfsstat3::NFS3ERR_NOENT)?;
+
+        Ok(target.into_bytes().into())
+    }
+}


### PR DESCRIPTION
Implements the `agentfs run` command on macOS using a userspace NFS server instead of FUSE. This enables copy-on-write sandboxing without requiring macFUSE or FSKit system extensions.