### PR TITLE
Add VFS-style File trait for efficient file handle operations

### DIFF
--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -14,8 +14,8 @@ use turso::{Builder, Connection, Value};
 #[cfg(unix)]
 pub use filesystem::HostFS;
 pub use filesystem::{
-    DirEntry, FileSystem, FilesystemStats, FsError, OverlayFS, Stats, DEFAULT_DIR_MODE,
-    DEFAULT_FILE_MODE, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG,
+    BoxedFile, DirEntry, File, FileSystem, FilesystemStats, FsError, OverlayFS, Stats,
+    DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG,
 };
 pub use kvstore::KvStore;
 pub use toolcalls::{ToolCall, ToolCallStats, ToolCallStatus, ToolCalls};


### PR DESCRIPTION
This adds a proper File trait to the SDK filesystem layer, similar to how POSIX file descriptors work. Instead of doing path lookups on every read/write/fsync operation, we now resolve the path once at open() time and operate directly on the file handle.