### PR TITLE
Add symlink support to FUSE filesystem

### DIFF
--- a/sdk/rust/src/filesystem/overlayfs.rs
+++ b/sdk/rust/src/filesystem/overlayfs.rs
@@ -364,7 +364,11 @@ impl OverlayFS {
 
             match stats {
                 Some(s) if s.is_directory() => {
-                    // Already a directory, continue
+                    // Directory exists in base or delta
+                    // Make sure it exists in delta too (required for delta operations)
+                    if self.delta.stat(&current).await?.is_none() {
+                        self.delta.mkdir(&current).await?;
+                    }
                 }
                 Some(_) => {
                     // Exists but not a directory - this is an error


### PR DESCRIPTION
Two issues were preventing symlink creation in agentfs run:

1. The FUSE implementation was missing the symlink() callback, causing EPERM when tools like npm tried to create symlinks in node_modules/.bin/

2. The OverlayFS ensure_parent_dirs() didn't create parent directories in the delta layer when they only existed in the base layer. This caused the delta layer's symlink/write operations to fail with "parent directory does not exist" since they only look up parents in the delta database.

Also adds symlink creation tests to test-mount.sh and test-symlinks.sh.