### PR TITLE
Add agentfs() convenience function for just-bash integration

### DIFF
--- a/examples/ai-sdk-just-bash/agent.ts
+++ b/examples/ai-sdk-just-bash/agent.ts
@@ -14,7 +14,6 @@ import { glob } from "glob";
 import { anthropic } from "@ai-sdk/anthropic";
 import { streamText, stepCountIs } from "ai";
 import { createBashTool } from "just-bash/ai";
-import { AgentFS } from "agentfs-sdk";
 import { agentfs } from "agentfs-sdk/just-bash";
 
 export interface AgentRunner {
@@ -40,7 +39,7 @@ export async function createAgent(
   options: CreateAgentOptions = {}
 ): Promise<AgentRunner> {
   // Open AgentFS for persistent storage
-  const fs = agentfs(await AgentFS.open({ id: "just-bash-agent" }));
+  const fs = await agentfs({ id: "just-bash-agent" });
 
   // Seed agentfs source files on first run
   const agentfsRoot = path.resolve(import.meta.dirname, "../..");

--- a/sdk/typescript/src/integrations/just-bash/AgentFs.ts
+++ b/sdk/typescript/src/integrations/just-bash/AgentFs.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Filesystem } from "../../filesystem.js";
+import { AgentFS, type AgentFSOptions } from "../../index_node.js";
 import type {
   BufferEncoding,
   CpOptions,
@@ -522,13 +523,19 @@ export class AgentFsWrapper implements IFileSystem {
  *
  * @example
  * ```ts
- * import { AgentFS } from "agentfs-sdk";
  * import { agentfs } from "agentfs-sdk/just-bash";
  *
- * const fs = agentfs(await AgentFS.open({ path: "agent.db" }));
+ * const fs = await agentfs({ path: "agent.db" });
  * const bashTool = createBashTool({ fs });
  * ```
  */
-export function agentfs(handle: AgentFsHandle, mountPoint?: string): IFileSystem {
+export async function agentfs(
+  handleOrOptions: AgentFsHandle | AgentFSOptions,
+  mountPoint?: string
+): Promise<IFileSystem> {
+  if ("fs" in handleOrOptions) {
+    return new AgentFsWrapper({ fs: handleOrOptions, mountPoint });
+  }
+  const handle = await AgentFS.open(handleOrOptions);
   return new AgentFsWrapper({ fs: handle, mountPoint });
 }


### PR DESCRIPTION
Simplify the API to a single import and call:

  import { agentfs } from "agentfs-sdk/just-bash";

  const fs = await agentfs({ path: "agent.db" });
  const bashTool = createBashTool({ fs });

The function accepts either AgentFSOptions (opens internally) or an existing AgentFS handle for more control.