### PR TITLE
Implement symlink following in TypeScript SDK

### DIFF
--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -9,6 +9,7 @@ export type FsErrorCode =
   | 'ENOTEMPTY' // Directory not empty
   | 'EPERM'     // Operation not permitted
   | 'EINVAL'    // Invalid argument
+  | 'ELOOP'     // Too many levels of symbolic links
   | 'ENOSYS';   // Function not implemented (use for symlinks)
 
 /**
@@ -18,6 +19,7 @@ export type FsErrorCode =
 export type FsSyscall =
   | 'open'
   | 'stat'
+  | 'lstat'
   | 'mkdir'
   | 'rmdir'
   | 'rm'


### PR DESCRIPTION
- stat() now follows symlinks up to 40 levels (matching Rust SDK)
- lstat() returns symlink stats without following (POSIX-compliant)
- normalizePath() properly handles . and .. path segments
- Added ELOOP error code for symlink loop detection
- Added comprehensive symlink tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)