### PR TITLE
agentfs run: Fix O_APPEND not appending a file

### DIFF
--- a/cli/tests/all.sh
+++ b/cli/tests/all.sh
@@ -4,7 +4,17 @@ set -e
 DIR="$(dirname "$0")"
 
 "$DIR/test-init.sh"
-"$DIR/test-syscalls.sh"
+
+# Syscall tests in three configurations:
+# 1. Linux baseline - establishes expected behavior
+"$DIR/test-linux-syscalls.sh"
+
+# 2. ptrace-based sandbox (--experimental-sandbox)
+"$DIR/test-run-experimental-syscalls.sh"
+
+# 3. FUSE overlay (agentfs run) - tests copy-on-write
+"$DIR/test-run-syscalls.sh" || true  # Requires user namespaces (may fail in CI)
+
 "$DIR/test-run-bash.sh" || true  # Requires user namespaces (may fail in CI)
 "$DIR/test-mount.sh"
 "$DIR/test-symlinks.sh" || true  # Requires user namespaces (may fail in CI)

--- a/cli/tests/syscall/Makefile
+++ b/cli/tests/syscall/Makefile
@@ -13,7 +13,8 @@ SRCS = main.c \
        test-stat.c \
        test-fstat.c \
        test-lstat.c \
-       test-getdents64.c
+       test-getdents64.c \
+       test-append.c
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/cli/tests/syscall/main.c
+++ b/cli/tests/syscall/main.c
@@ -28,6 +28,7 @@ int main(int argc, char *argv[]) {
         {"fstat", test_fstat},
         {"lstat", test_lstat},
         {"getdents64", test_getdents64},
+        {"append_existing", test_append_existing},
     };
 
     int num_tests = sizeof(tests) / sizeof(tests[0]);

--- a/cli/tests/syscall/test-append.c
+++ b/cli/tests/syscall/test-append.c
@@ -1,0 +1,139 @@
+#define _GNU_SOURCE
+#include "test-common.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+/*
+ * Tests for O_APPEND on EXISTING files.
+ *
+ * This is critical for overlay filesystems where the file exists in the
+ * base layer and must be copied-on-write when modified.
+ *
+ * The test harness MUST create "existing.txt" with known content BEFORE
+ * running this test.
+ */
+
+int test_append_existing(const char *base_path) {
+    char path[512];
+    char read_buf[1024];
+    int fd;
+    ssize_t n;
+    struct stat st;
+
+    snprintf(path, sizeof(path), "%s/existing.txt", base_path);
+
+    /* Verify the file exists (created by test harness) */
+    if (stat(path, &st) != 0) {
+        fprintf(stderr, "  Note: existing.txt not found, skipping test_append_existing\n");
+        fprintf(stderr, "  (This test requires the harness to create existing.txt first)\n");
+        return 0;  /* Skip, not fail */
+    }
+
+    off_t original_size = st.st_size;
+    printf("  existing.txt found, size=%ld bytes\n", (long)original_size);
+
+    /* Read original content */
+    fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open existing.txt for read should succeed");
+
+    n = read(fd, read_buf, sizeof(read_buf) - 1);
+    TEST_ASSERT_ERRNO(n >= 0, "read original content should succeed");
+    read_buf[n] = '\0';
+    close(fd);
+
+    char original_content[1024];
+    strncpy(original_content, read_buf, sizeof(original_content) - 1);
+    original_content[sizeof(original_content) - 1] = '\0';
+    printf("  original content: \"%s\"\n", original_content);
+
+    /* Test 1: Open with O_APPEND and write */
+    fd = open(path, O_WRONLY | O_APPEND);
+    TEST_ASSERT_ERRNO(fd >= 0, "open with O_APPEND should succeed");
+
+    const char *append_data = "[APPENDED]";
+    n = write(fd, append_data, strlen(append_data));
+    TEST_ASSERT_ERRNO(n == (ssize_t)strlen(append_data), "append write should write all bytes");
+    close(fd);
+
+    /* Test 2: Verify file size increased */
+    TEST_ASSERT_ERRNO(stat(path, &st) == 0, "stat after append should succeed");
+    TEST_ASSERT(st.st_size == original_size + (off_t)strlen(append_data),
+                "file size should increase by appended bytes");
+    printf("  after append, size=%ld bytes\n", (long)st.st_size);
+
+    /* Test 3: Read back and verify content */
+    fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open for read after append should succeed");
+
+    n = read(fd, read_buf, sizeof(read_buf) - 1);
+    TEST_ASSERT_ERRNO(n > 0, "read after append should succeed");
+    read_buf[n] = '\0';
+    close(fd);
+
+    printf("  after append content: \"%s\"\n", read_buf);
+
+    /* Verify original content is preserved at the start */
+    TEST_ASSERT(strncmp(read_buf, original_content, strlen(original_content)) == 0,
+                "original content should be preserved");
+
+    /* Verify appended content is at the end */
+    TEST_ASSERT(strcmp(read_buf + strlen(original_content), append_data) == 0,
+                "appended content should be at the end");
+
+    /* Test 4: Multiple appends */
+    fd = open(path, O_WRONLY | O_APPEND);
+    TEST_ASSERT_ERRNO(fd >= 0, "second open with O_APPEND should succeed");
+
+    const char *append_data2 = "[MORE]";
+    n = write(fd, append_data2, strlen(append_data2));
+    TEST_ASSERT_ERRNO(n == (ssize_t)strlen(append_data2), "second append should succeed");
+    close(fd);
+
+    /* Verify both appends are present */
+    fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open for final read should succeed");
+
+    n = read(fd, read_buf, sizeof(read_buf) - 1);
+    TEST_ASSERT_ERRNO(n > 0, "final read should succeed");
+    read_buf[n] = '\0';
+    close(fd);
+
+    printf("  final content: \"%s\"\n", read_buf);
+
+    /* Build expected content */
+    char expected[1024];
+    snprintf(expected, sizeof(expected), "%s%s%s", original_content, append_data, append_data2);
+
+    TEST_ASSERT(strcmp(read_buf, expected) == 0,
+                "final content should match original + both appends");
+
+    /* Test 5: O_APPEND with O_RDWR */
+    fd = open(path, O_RDWR | O_APPEND);
+    TEST_ASSERT_ERRNO(fd >= 0, "open with O_RDWR | O_APPEND should succeed");
+
+    /* Read should work from beginning */
+    n = read(fd, read_buf, 5);
+    TEST_ASSERT_ERRNO(n > 0, "read with O_RDWR | O_APPEND should succeed");
+
+    /* Write should still append */
+    const char *append_data3 = "[END]";
+    n = write(fd, append_data3, strlen(append_data3));
+    TEST_ASSERT_ERRNO(n == (ssize_t)strlen(append_data3), "write with O_RDWR | O_APPEND should append");
+    close(fd);
+
+    /* Final verification */
+    fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "final open should succeed");
+    n = read(fd, read_buf, sizeof(read_buf) - 1);
+    read_buf[n] = '\0';
+    close(fd);
+
+    snprintf(expected, sizeof(expected), "%s%s%s%s", original_content, append_data, append_data2, append_data3);
+    TEST_ASSERT(strcmp(read_buf, expected) == 0,
+                "content after O_RDWR | O_APPEND should be correct");
+
+    printf("  all append tests passed\n");
+
+    return 0;
+}

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -45,5 +45,6 @@ int test_stat(const char *base_path);
 int test_fstat(const char *base_path);
 int test_lstat(const char *base_path);
 int test_getdents64(const char *base_path);
+int test_append_existing(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/cli/tests/test-linux-syscalls.sh
+++ b/cli/tests/test-linux-syscalls.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Test syscalls directly on Linux (baseline).
+#
+# This establishes the expected behavior that AgentFS should match.
+#
+set -e
+
+echo -n "TEST syscalls (Linux baseline)... "
+
+DIR="$(dirname "$0")"
+
+# Compile the test program
+make -C "$DIR/syscall" clean > /dev/null 2>&1
+make -C "$DIR/syscall" > /dev/null 2>&1
+
+# Create a temporary test directory
+TEST_DIR=$(mktemp -d)
+trap "rm -rf '$TEST_DIR'" EXIT
+
+# Create pre-existing files for overlay-style tests
+echo -n "original content" > "$TEST_DIR/existing.txt"
+echo "Hello from test setup!" > "$TEST_DIR/test.txt"
+
+# Run syscall tests directly on Linux
+if ! output=$("$DIR/syscall/test-syscalls" "$TEST_DIR" 2>&1); then
+    echo "FAILED"
+    echo "Output was: $output"
+    exit 1
+fi
+
+echo "$output" | grep -q "All tests passed!" || {
+    echo "FAILED: 'All tests passed!' not found"
+    echo "Output was: $output"
+    exit 1
+}
+
+echo "OK"

--- a/cli/tests/test-run-syscalls.sh
+++ b/cli/tests/test-run-syscalls.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Test syscalls through agentfs run (FUSE overlay).
+#
+# This tests the copy-on-write behavior when files exist in the base layer
+# (host filesystem) and are modified through the overlay.
+#
+# Requires user namespaces support.
+#
+set -e
+
+echo -n "TEST syscalls (agentfs run - FUSE overlay)... "
+
+DIR="$(dirname "$0")"
+
+# Compile the test program
+make -C "$DIR/syscall" clean > /dev/null 2>&1
+make -C "$DIR/syscall" > /dev/null 2>&1
+
+TEST_DB="agent.db"
+
+# Clean up any existing test database
+rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm"
+
+# Initialize the database
+cargo run -- init > /dev/null 2>&1
+
+# Create pre-existing files in the BASE LAYER (current directory)
+# These will trigger copy-on-write when modified through the overlay
+echo -n "original content" > existing.txt
+echo "Hello from test setup!" > test.txt
+
+# Run syscall tests through FUSE overlay
+# The test binary runs inside the overlay where:
+# - Files from current directory are visible (base layer)
+# - Modifications go to the delta layer (AgentFS database)
+# - O_APPEND on existing.txt triggers copy-on-write
+if ! output=$(cargo run -- run "$DIR/syscall/test-syscalls" . 2>&1); then
+    echo "FAILED"
+    echo "Output was: $output"
+    rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm" existing.txt test.txt
+    exit 1
+fi
+
+echo "$output" | grep -q "All tests passed!" || {
+    echo "FAILED: 'All tests passed!' not found"
+    echo "Output was: $output"
+    rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm" existing.txt test.txt
+    exit 1
+}
+
+# Note: output.txt is created in the delta layer (session-specific) so we can't
+# verify it with a separate agentfs run. The "All tests passed!" check is sufficient.
+
+rm -f "$TEST_DB" "${TEST_DB}-wal" "${TEST_DB}-shm" existing.txt test.txt
+
+echo "OK"


### PR DESCRIPTION
The experimental ptrace-based sandbox did not implement O_APPEND correctly. Make the system call test cases run with different configurations while at it.