### PR TITLE
agentfs run: Fix nested pwrite() on overlay filesystem

### DIFF
--- a/cli/tests/syscall/main.c
+++ b/cli/tests/syscall/main.c
@@ -29,6 +29,7 @@ int main(int argc, char *argv[]) {
         {"lstat", test_lstat},
         {"getdents64", test_getdents64},
         {"append_existing", test_append_existing},
+        {"pwrite_nested", test_pwrite_nested},
     };
 
     int num_tests = sizeof(tests) / sizeof(tests[0]);

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -46,5 +46,6 @@ int test_fstat(const char *base_path);
 int test_lstat(const char *base_path);
 int test_getdents64(const char *base_path);
 int test_append_existing(const char *base_path);
+int test_pwrite_nested(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/cli/tests/test-linux-syscalls.sh
+++ b/cli/tests/test-linux-syscalls.sh
@@ -22,6 +22,10 @@ trap "rm -rf '$TEST_DIR'" EXIT
 echo -n "original content" > "$TEST_DIR/existing.txt"
 echo "Hello from test setup!" > "$TEST_DIR/test.txt"
 
+# Create nested directory structure for COW parent dir test
+mkdir -p "$TEST_DIR/subdir"
+echo -n "nested content" > "$TEST_DIR/subdir/nested.txt"
+
 # Run syscall tests directly on Linux
 if ! output=$("$DIR/syscall/test-syscalls" "$TEST_DIR" 2>&1); then
     echo "FAILED"

--- a/cli/tests/test-run-experimental-syscalls.sh
+++ b/cli/tests/test-run-experimental-syscalls.sh
@@ -30,6 +30,10 @@ cargo run -- run --experimental-sandbox /bin/bash -c 'echo "Hello from virtual F
 # Create existing.txt for the append test
 cargo run -- run --experimental-sandbox /bin/bash -c 'echo -n "original content" > /agent/existing.txt' > /dev/null 2>&1
 
+# Note: The nested directory test (test_append_nested) is skipped for experimental sandbox
+# because it tests FUSE overlay COW behavior where parent dirs need to be created in delta.
+# The experimental sandbox has no base layer, so this scenario doesn't apply.
+
 # Run the syscall tests using the experimental ptrace-based sandbox
 if ! output=$(cargo run -- run --experimental-sandbox "$DIR/syscall/test-syscalls" /agent 2>&1); then
     echo "FAILED"


### PR DESCRIPTION
When running `git switch` in an `agentfs run` session, we got the following error:

```
penberg@turing:~/src/tursodatabase/agentfs$ agentfs run bash
Welcome to AgentFS!

The following directories are writable:

  - /home/penberg/src/tursodatabase/agentfs (copy-on-write)
  - /home/penberg/.claude
  - /home/penberg/.claude.json
  - /home/penberg/.local
  - /home/penberg/.npm

Everything else is read-only.

To join this session from another terminal:

  agentfs run --session be3e8fff-88d0-417d-a3e7-71467320f132 <command>

🤖 penberg@turing:~/src/tursodatabase/agentfs$ git switch main
error: cannot update the ref 'HEAD': unable to append to '.git/logs/HEAD': Input/output error
fatal: unable to update HEAD
```

As it turns out, the issue was that pwrite() was not handling nested paths correctly in overlay filesystem.