### PR TITLE
Remove macFUSE support on macOS

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9,7 +9,7 @@ AgentFS provides the following components:
 1. SDK - TypeScript and Rust libraries for programmatic filesystem access
 2. CLI - Command-line interface for managing agent filesystems
 3. Specification - SQLite-based agent filesystem specification
-4. FUSE Mount - Mount agent filesystems on the host using FUSE
+4. FUSE/NFS Mount - Mount agent filesystems on the host using FUSE (Linux) or NFS (macOS)
 5. Overlay Filesystem - Copy-on-write filesystem layer over host directories
 6. Sandbox - Linux-compatible execution environment with agent filesystem support (experimental)
 
@@ -41,7 +41,7 @@ Created agent filesystem: .agentfs/my-agent.db
 Agent ID: my-agent
 ```
 
-### 2. Mount the AgentFS filesystem with FUSE (Linux and macOS)
+### 2. Mount the AgentFS filesystem with FUSE (Linux) or NFS (macOS)
 
 Mount an AgentFS filesystem on the host:
 
@@ -149,7 +149,7 @@ The `.agentfs/` directory is automatically created if it doesn't exist.
 
 ### `agentfs mount`
 
-Mount an agent filesystem using FUSE (Linux and macOS).
+Mount an agent filesystem using FUSE (Linux) or NFS (macOS).
 
 **Usage:**
 ```bash
@@ -176,9 +176,8 @@ agentfs mount .agentfs/my-agent.db ./my-agent-mount
 Mounts the agent filesystem as a FUSE filesystem on the host, allowing you to interact with the agent's files using standard filesystem tools (ls, cat, cp, etc.).
 
 **Requirements:**
-- Linux or macOS operating system
-- FUSE must be installed on your system (on macOS, install [macFUSE](https://osxfuse.github.io/))
-- The CLI must be built with the `fuse` feature enabled
+- Linux: FUSE must be installed on your system
+- macOS: Uses NFS (no additional installation required)
 
 **Usage after mounting:**
 ```bash
@@ -192,7 +191,7 @@ cat ./my-agent-mount/hello.txt
 ls ./my-agent-mount/
 ```
 
-To unmount, use `fusermount -u ./my-agent-mount`.
+To unmount, use `fusermount -u ./my-agent-mount` on Linux or `umount ./my-agent-mount` on macOS.
 
 ### `agentfs run`
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The AgentFS repository consists of the following:
 
 * **SDK** - [TypeScript](sdk/typescript), [Python](sdk/python), and [Rust](sdk/rust) libraries for programmatic filesystem access.
 * **[CLI](MANUAL.md)** - Command-line interface for managing agent filesystems:
-  - Mount AgentFS on host filesystem with FUSE on Linux and macFUSE on macOS.
+  - Mount AgentFS on host filesystem with FUSE on Linux and NFS on macOS.
   - Access AgentFS files with a command line tool.
 * **[AgentFS Specification](SPEC.md)** - SQLite-based agent filesystem specification.
 
@@ -73,7 +73,7 @@ $ agentfs fs cat .agentfs/my-agent.db hello.txt
 hello from agent
 ```
 
-You can mount an agent filesystem using FUSE:
+You can mount an agent filesystem using FUSE (Linux) or NFS (macOS):
 
 ```bash
 $ agentfs mount my-agent ./mnt

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -795,7 +795,6 @@ dependencies = [
  "memchr",
  "nix 0.29.0",
  "page_size",
- "pkg-config",
  "smallvec",
  "zerocopy",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,12 +41,8 @@ reverie = { git = "https://github.com/facebookexperimental/reverie" }
 reverie-ptrace = { git = "https://github.com/facebookexperimental/reverie" }
 reverie-process = { git = "https://github.com/facebookexperimental/reverie" }
 
-# macOS dependencies for FUSE and NFS functionality
+# macOS dependencies for NFS functionality (no FUSE - uses nfsserve instead)
 [target.'cfg(target_os = "macos")'.dependencies]
-fuser = { version = "0.15", default-features = false, features = [
-    "abi-7-29",
-    "libfuse",
-] }
 # NFS server for userspace filesystem without FUSE (used by `agentfs run`)
 nfsserve = "0.10"
 uuid = { version = "1", features = ["v4"] }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -9,14 +9,6 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=gcc_s");
     }
 
-    // macOS: Weak-link libfuse so the binary can load without macFUSE installed.
-    #[cfg(target_os = "macos")]
-    {
-        println!("cargo:rustc-link-arg=-Wl,-weak-lfuse");
-        println!("cargo:rustc-link-search=/usr/local/lib");
-        println!("cargo:rustc-link-search=/Library/Frameworks/macFUSE.framework/Versions/A");
-    }
-
     // Capture git version from tags for --version flag
     // Rerun if git HEAD changes (new commits or tags)
     println!("cargo:rerun-if-changed=../.git/HEAD");

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -2,9 +2,9 @@ pub mod completions;
 pub mod fs;
 pub mod init;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 mod mount;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(target_os = "linux"))]
 #[path = "mount_stub.rs"]
 mod mount;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2,10 +2,10 @@ pub mod cmd;
 pub mod parser;
 pub mod sandbox;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 pub mod daemon;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 pub mod fuse;
 
 #[cfg(unix)]


### PR DESCRIPTION
Remove FUSE/macFUSE dependency on macOS in favor of using NFS via nfsserve. The `agentfs run` command already uses NFS on macOS, and the `agentfs mount` command now returns "FUSE mount is only available on Linux" on non-Linux platforms.