### PR TITLE
agentfs run: Use macOS Sandbox for filesystem isolation

### DIFF
--- a/cli/src/cmd/run_nfs.rs
+++ b/cli/src/cmd/run_nfs.rs
@@ -18,13 +18,16 @@ use tokio::sync::Mutex;
 
 use crate::nfs::AgentNFS;
 
+#[cfg(target_os = "macos")]
+use crate::sandbox::sandbox_macos::{generate_sandbox_profile, SandboxConfig};
+
 /// Default NFS port to try (use a high port to avoid needing root)
 const DEFAULT_NFS_PORT: u32 = 11111;
 
 /// Handle the `run` command using NFS on macOS.
 pub async fn handle_run_command(
-    _allow: Vec<PathBuf>,
-    _no_default_allows: bool,
+    allow: Vec<PathBuf>,
+    no_default_allows: bool,
     _experimental_sandbox: bool,
     _strace: bool,
     session_id: Option<String>,
@@ -32,8 +35,9 @@ pub async fn handle_run_command(
     args: Vec<String>,
 ) -> Result<()> {
     let cwd = std::env::current_dir().context("Failed to get current directory")?;
+    let home = dirs::home_dir().context("Failed to get home directory")?;
 
-    let session = setup_run_directory(session_id)?;
+    let session = setup_run_directory(session_id, allow, no_default_allows, &cwd, &home)?;
 
     // Initialize the AgentFS database
     let db_path_str = session
@@ -45,14 +49,14 @@ pub async fn handle_run_command(
         .await
         .context("Failed to create AgentFS")?;
 
-    // Create overlay filesystem with cwd as base
-    let cwd_str = cwd.to_string_lossy().to_string();
-    let hostfs = HostFS::new(&cwd_str).context("Failed to create HostFS")?;
+    // Create overlay filesystem with CWD as base
+    let base_str = cwd.to_string_lossy().to_string();
+    let hostfs = HostFS::new(&base_str).context("Failed to create HostFS")?;
     let overlay = OverlayFS::new(Arc::new(hostfs), agentfs.fs);
 
     // Initialize the overlay (copies directory structure)
     overlay
-        .init(&cwd_str)
+        .init(&base_str)
         .await
         .context("Failed to initialize overlay")?;
 
@@ -86,10 +90,10 @@ pub async fn handle_run_command(
     // Mount the NFS filesystem
     mount_nfs(port, &session.mountpoint)?;
 
-    print_welcome_banner(&session.mountpoint);
+    print_welcome_banner(&session);
 
     // Run the command
-    let exit_code = run_command_in_mount(&session.mountpoint, &session.run_dir, command, args)?;
+    let exit_code = run_command_in_mount(&session, command, args)?;
 
     // Unmount
     unmount(&session.mountpoint)?;
@@ -116,11 +120,33 @@ pub async fn handle_run_command(
     std::process::exit(exit_code);
 }
 
-/// Print the welcome banner showing sandbox configuration.
-fn print_welcome_banner(cwd: &Path) {
+/// Print the welcome banner showing sandbox configuration (macOS).
+#[cfg(target_os = "macos")]
+fn print_welcome_banner(session: &RunSession) {
     eprintln!("Welcome to AgentFS!");
     eprintln!();
-    eprintln!("  {} (copy-on-write)", cwd.display());
+    eprintln!("The following directories are writable:");
+    eprintln!();
+    eprintln!("  - {} (copy-on-write)", session.cwd.display());
+    eprintln!("  - /tmp");
+    for path in &session.allow_paths {
+        eprintln!("  - {}", path.display());
+    }
+    eprintln!();
+    eprintln!("🔒 Everything else is read-only.");
+    eprintln!();
+    eprintln!("To join this session from another terminal:");
+    eprintln!();
+    eprintln!("  agentfs run --session {} <command>", session.session_id);
+    eprintln!();
+}
+
+/// Print the welcome banner showing sandbox configuration (Linux).
+#[cfg(target_os = "linux")]
+fn print_welcome_banner(session: &RunSession) {
+    eprintln!("Welcome to AgentFS!");
+    eprintln!();
+    eprintln!("  {} (copy-on-write)", session.cwd.display());
     eprintln!("  ⚠️  Everything else is WRITABLE.");
     eprintln!();
 }
@@ -133,32 +159,68 @@ struct RunSession {
     db_path: PathBuf,
     /// Path where NFS filesystem will be mounted.
     mountpoint: PathBuf,
+    /// Session ID for the sandbox profile.
+    session_id: String,
+    /// Additional paths to allow write access.
+    allow_paths: Vec<PathBuf>,
+    /// Original working directory.
+    cwd: PathBuf,
 }
+
+/// Default directories in HOME that are allowed to be writable.
+/// These are common application config/cache directories that many programs need.
+const DEFAULT_ALLOWED_DIRS: &[&str] = &[
+    ".claude",      // Claude Code config
+    ".claude.json", // Claude Code config file
+    ".local",       // Local data directory
+    ".npm",         // npm local registry
+    ".config",      // XDG config directory
+    ".cache",       // XDG cache directory
+];
 
 /// Create a run directory with database and mountpoint paths.
 ///
 /// If `session_id` is provided, uses that as the run ID (allowing multiple
 /// runs to share the same delta layer). Otherwise generates a unique UUID.
-fn setup_run_directory(session_id: Option<String>) -> Result<RunSession> {
+fn setup_run_directory(
+    session_id: Option<String>,
+    user_allow_paths: Vec<PathBuf>,
+    no_default_allows: bool,
+    cwd: &Path,
+    home: &Path,
+) -> Result<RunSession> {
     let run_id = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    let home_dir = dirs::home_dir().context("Failed to get home directory")?;
-    let run_dir = home_dir.join(".agentfs").join("run").join(&run_id);
+    let run_dir = home.join(".agentfs").join("run").join(&run_id);
     std::fs::create_dir_all(&run_dir).context("Failed to create run directory")?;
 
     let db_path = run_dir.join("delta.db");
     let mountpoint = run_dir.join("mnt");
     std::fs::create_dir_all(&mountpoint).context("Failed to create mountpoint")?;
 
+    // Build allowed paths list
+    let mut allow_paths = user_allow_paths;
+    if !no_default_allows {
+        for dir in DEFAULT_ALLOWED_DIRS {
+            let path = home.join(dir);
+            if path.exists() {
+                allow_paths.push(path);
+            }
+        }
+    }
+
     // Create zsh config directory with custom prompt
     let zsh_dir = run_dir.join("zsh");
     std::fs::create_dir_all(&zsh_dir).context("Failed to create zsh config directory")?;
-    std::fs::write(zsh_dir.join(".zshrc"), "PROMPT='🤖 %n@%m:%~%# '\n")
+    std::fs::write(zsh_dir.join(".zshrc"), "PROMPT='🤖 %~%# '\n")
         .context("Failed to write zsh config")?;
 
     Ok(RunSession {
         run_dir,
         db_path,
         mountpoint,
+        session_id: run_id,
+        allow_paths,
+        cwd: cwd.to_path_buf(),
     })
 }
 
@@ -229,21 +291,59 @@ fn mount_nfs(port: u32, mountpoint: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Run a command with the working directory set to the mounted filesystem.
-fn run_command_in_mount(
-    mountpoint: &Path,
-    run_dir: &Path,
-    command: PathBuf,
-    args: Vec<String>,
-) -> Result<i32> {
+/// Run a command with the working directory set to the mounted filesystem (macOS).
+///
+/// On macOS, the command is wrapped with sandbox-exec using a Sandbox profile
+/// that restricts file writes to the NFS mountpoint and allowed paths.
+/// The mountpoint overlays CWD, and additional paths in HOME are made writable
+/// through the allow_paths configuration.
+#[cfg(target_os = "macos")]
+fn run_command_in_mount(session: &RunSession, command: PathBuf, args: Vec<String>) -> Result<i32> {
+    // Generate the Sandbox profile
+    let config = SandboxConfig {
+        mountpoint: session.mountpoint.clone(),
+        allow_paths: session.allow_paths.clone(),
+        allow_read_paths: Vec::new(),
+        allow_network: true,
+        session_id: session.session_id.clone(),
+    };
+    let profile = generate_sandbox_profile(&config);
+
+    // Wrap the command with sandbox-exec
+    let mut cmd = Command::new("sandbox-exec");
+    cmd.arg("-p")
+        .arg(&profile)
+        .arg(&command)
+        .args(&args)
+        .current_dir(&session.mountpoint)
+        .env("AGENTFS", "1")
+        .env("AGENTFS_SANDBOX", "macos-sandbox")
+        // Bash prompt - show full path since we're not changing HOME
+        .env("PS1", "🤖 \\w\\$ ")
+        // Zsh: use custom ZDOTDIR to override prompt
+        .env("ZDOTDIR", session.run_dir.join("zsh"));
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Failed to execute command: {}", command.display()))?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Run a command with the working directory set to the mounted filesystem (Linux).
+///
+/// On Linux, the command runs without additional sandboxing (NFS provides
+/// copy-on-write for the working directory).
+#[cfg(target_os = "linux")]
+fn run_command_in_mount(session: &RunSession, command: PathBuf, args: Vec<String>) -> Result<i32> {
     let mut cmd = Command::new(&command);
     cmd.args(&args)
-        .current_dir(mountpoint)
+        .current_dir(&session.mountpoint)
         .env("AGENTFS", "1")
         // Bash prompt
         .env("PS1", "🤖 \\u@\\h:\\w\\$ ")
         // Zsh: use custom ZDOTDIR to override prompt
-        .env("ZDOTDIR", run_dir.join("zsh"));
+        .env("ZDOTDIR", session.run_dir.join("zsh"));
 
     let status = cmd
         .status()

--- a/cli/src/sandbox/mod.rs
+++ b/cli/src/sandbox/mod.rs
@@ -1,11 +1,15 @@
 //! Sandbox implementations for running commands in isolated environments.
 //!
-//! This module provides two sandbox approaches:
-//! - `overlay`: FUSE + namespace-based sandbox with copy-on-write filesystem
-//! - `ptrace`: ptrace-based syscall interception sandbox (experimental)
+//! This module provides platform-specific sandbox approaches:
+//! - `overlay`: (Linux) FUSE + namespace-based sandbox with copy-on-write filesystem
+//! - `ptrace`: (Linux) ptrace-based syscall interception sandbox (experimental)
+//! - `sandbox_macos`: (macOS) Kernel-enforced sandbox using sandbox-exec
 
 #[cfg(target_os = "linux")]
 pub mod overlay;
 
 #[cfg(target_os = "linux")]
 pub mod ptrace;
+
+#[cfg(target_os = "macos")]
+pub mod sandbox_macos;

--- a/cli/src/sandbox/overlay.rs
+++ b/cli/src/sandbox/overlay.rs
@@ -297,7 +297,7 @@ fn print_welcome_banner(cwd: &Path, allowed_paths: &[PathBuf], session_id: &str)
         eprintln!("  - {}", path.display());
     }
     eprintln!();
-    eprintln!("Everything else is read-only.");
+    eprintln!("🔒 Everything else is read-only.");
     eprintln!();
     eprintln!("To join this session from another terminal:");
     eprintln!();
@@ -927,6 +927,7 @@ fn exec_command(command: PathBuf, args: Vec<String>, session_id: &str) -> ! {
 /// Setup environment variables for the sandbox.
 fn setup_env_vars(session_id: &str) {
     std::env::set_var("AGENTFS", "1");
+    std::env::set_var("AGENTFS_SANDBOX", "linux-container");
     std::env::set_var("AGENTFS_SESSION", session_id);
     std::env::set_var("PS1", "🤖 \\u@\\h:\\w\\$ ");
 

--- a/cli/src/sandbox/sandbox_macos.rs
+++ b/cli/src/sandbox/sandbox_macos.rs
@@ -1,0 +1,287 @@
+//! macOS Sandbox sandbox support for AgentFS.
+//!
+//! This module provides kernel-enforced sandboxing using macOS's sandbox-exec
+//! with dynamically generated Sandbox profiles. When enabled, the spawned
+//! process can only access the NFS mountpoint and explicitly allowed paths.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let config = SandboxConfig {
+//!     mountpoint: PathBuf::from("/Users/me/.agentfs/run/abc/mnt"),
+//!     allow_paths: vec![PathBuf::from("/tmp")],
+//!     allow_network: false,
+//!     session_id: "abc123".to_string(),
+//! };
+//! let profile = generate_sandbox_profile(&config);
+//! let wrapped = wrap_command_with_sandbox(&config, "zsh", &[]);
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Configuration for the Sandbox sandbox.
+#[derive(Debug, Clone)]
+pub struct SandboxConfig {
+    /// The NFS mountpoint (primary read/write location).
+    pub mountpoint: PathBuf,
+
+    /// Additional paths to allow read/write access.
+    pub allow_paths: Vec<PathBuf>,
+
+    /// Additional paths to allow read-only access.
+    pub allow_read_paths: Vec<PathBuf>,
+
+    /// Whether to allow network access.
+    pub allow_network: bool,
+
+    /// Session ID for log filtering (used in violation messages).
+    pub session_id: String,
+}
+
+impl Default for SandboxConfig {
+    fn default() -> Self {
+        Self {
+            mountpoint: PathBuf::new(),
+            allow_paths: Vec::new(),
+            allow_read_paths: Vec::new(),
+            allow_network: false,
+            session_id: String::new(),
+        }
+    }
+}
+
+/// Generate a Sandbox profile for AgentFS.
+///
+/// The profile allows most operations but restricts file writes to:
+/// - The NFS mountpoint (which overlays CWD)
+/// - Temp directories (/tmp, /var/folders)
+/// - Explicitly allowed paths (e.g., ~/.claude, ~/.config, etc.)
+///
+/// This approach is simpler and more reliable than trying to enumerate
+/// all paths a process might need to read.
+pub fn generate_sandbox_profile(config: &SandboxConfig) -> String {
+    let mut profile = Vec::new();
+    let log_tag = format!("agentfs-{}", config.session_id);
+
+    // Version and deny by default for file writes
+    profile.push("(version 1)".to_string());
+    profile.push(format!(
+        r#"(deny default (with message "agentfs-{}: write denied"))"#,
+        config.session_id
+    ));
+    profile.push(format!("; Log tag: {}", log_tag));
+
+    // =========================================================================
+    // Allow most operations - we only want to restrict file writes
+    // =========================================================================
+    profile.push("; Allow most operations".to_string());
+    profile.push("(allow process*)".to_string());
+    profile.push("(allow signal)".to_string());
+    profile.push("(allow mach*)".to_string());
+    profile.push("(allow sysctl*)".to_string());
+    profile.push("(allow system*)".to_string());
+    profile.push("(allow ipc*)".to_string());
+    profile.push("(allow pseudo-tty)".to_string());
+
+    // =========================================================================
+    // Allow all file reads - the overlay handles copy-on-write
+    // =========================================================================
+    profile.push("; Allow all file reads".to_string());
+    profile.push("(allow file-read*)".to_string());
+
+    // =========================================================================
+    // Writable paths - these are the only places writes are allowed
+    // =========================================================================
+    profile.push("; Writable paths".to_string());
+
+    // The NFS mountpoint - primary workspace (overlays CWD)
+    let mountpoint_str = config.mountpoint.to_string_lossy();
+    profile.push(format!(
+        r#"(allow file-write* (subpath "{}"))"#,
+        mountpoint_str
+    ));
+
+    // The run directory (for zsh config, etc.)
+    if let Some(parent) = config.mountpoint.parent() {
+        let run_dir_str = parent.to_string_lossy();
+        profile.push(format!(
+            r#"(allow file-write* (subpath "{}"))"#,
+            run_dir_str
+        ));
+    }
+
+    // Temp directories (many tools require these)
+    profile.push(r#"(allow file-write* (subpath "/private/tmp"))"#.to_string());
+    profile.push(r#"(allow file-write* (subpath "/tmp"))"#.to_string());
+    profile.push(r#"(allow file-write* (subpath "/var/tmp"))"#.to_string());
+
+    // Private var folders (per-user temp space)
+    profile.push(r#"(allow file-write* (subpath "/private/var/folders"))"#.to_string());
+
+    // Device files (terminals, etc.)
+    profile.push(r#"(allow file-write* (subpath "/dev"))"#.to_string());
+    profile.push(r#"(allow file-ioctl (subpath "/dev"))"#.to_string());
+
+    // Additional writable paths from config
+    for path in &config.allow_paths {
+        let path_str = path.to_string_lossy();
+        profile.push(format!(r#"(allow file-write* (subpath "{}"))"#, path_str));
+    }
+
+    // =========================================================================
+    // Network access
+    // =========================================================================
+    profile.push("; Network".to_string());
+    if config.allow_network {
+        profile.push("(allow network*)".to_string());
+    } else {
+        // Only allow localhost for NFS
+        profile.push(r#"(allow network* (remote ip "localhost:*"))"#.to_string());
+        profile.push(r#"(allow network* (local ip "localhost:*"))"#.to_string());
+    }
+
+    // =========================================================================
+    // Security and Keychain - needed for credential storage
+    // =========================================================================
+    profile.push("; Security and Keychain".to_string());
+    profile.push(r#"(allow file-write* (subpath "/private/var/db/mds"))"#.to_string());
+    profile.push(
+        r#"(allow file-write* (regex #"^/private/var/folders/[^/]+/[^/]+/C/mds/"))"#.to_string(),
+    );
+    profile
+        .push(r#"(allow file-write* (regex #"^/private/var/folders/[^/]+/[^/]+/T/"))"#.to_string());
+    // User Library paths for Keychain and security services
+    if let Some(home) = dirs::home_dir() {
+        let home_str = home.to_string_lossy();
+        profile.push(format!(
+            r#"(allow file-write* (subpath "{}/Library"))"#,
+            home_str
+        ));
+    }
+    // System Library for preferences
+    profile.push(r#"(allow file-write* (subpath "/Library/Preferences"))"#.to_string());
+    profile.push(r#"(allow file-write* (subpath "/Library/Keychains"))"#.to_string());
+    // Authorization and user preference operations
+    profile.push("(allow authorization-right-obtain)".to_string());
+    profile.push("(allow user-preference-write)".to_string());
+    profile.push("(allow user-preference-read)".to_string());
+
+    profile.join("\n")
+}
+
+/// Wrap a command with sandbox-exec.
+///
+/// Returns a Command configured to run the given program inside the sandbox.
+pub fn wrap_command_with_sandbox(
+    config: &SandboxConfig,
+    program: &Path,
+    args: &[String],
+) -> Command {
+    let profile = generate_sandbox_profile(config);
+
+    let mut cmd = Command::new("sandbox-exec");
+    cmd.arg("-p").arg(&profile);
+    cmd.arg(program);
+    cmd.args(args);
+    cmd.current_dir(&config.mountpoint);
+
+    // Set environment variables
+    cmd.env("AGENTFS", "1");
+    cmd.env("AGENTFS_SANDBOX", "seatbelt");
+
+    cmd
+}
+
+/// Generate a minimal Sandbox profile for testing.
+///
+/// This profile is more permissive and useful for debugging sandbox issues.
+pub fn generate_permissive_profile(config: &SandboxConfig) -> String {
+    let mut profile = Vec::new();
+    let log_tag = format!("agentfs-{}", config.session_id);
+
+    profile.push("(version 1)".to_string());
+
+    // Log denials but don't block most things
+    profile.push(format!("(deny default (with message \"{}\")))", log_tag));
+
+    // Allow almost everything for debugging
+    profile.push("(allow process*)".to_string());
+    profile.push("(allow file-read*)".to_string());
+    profile.push("(allow mach*)".to_string());
+    profile.push("(allow sysctl*)".to_string());
+    profile.push("(allow signal)".to_string());
+    profile.push("(allow ipc*)".to_string());
+    profile.push("(allow pseudo-tty)".to_string());
+    profile.push("(allow system*)".to_string());
+
+    // Only restrict writes to outside mountpoint
+    let mountpoint_str = config.mountpoint.to_string_lossy();
+    profile.push(format!(
+        r#"(allow file-write* (subpath "{}"))"#,
+        mountpoint_str
+    ));
+    profile.push(r#"(allow file-write* (subpath "/private/tmp"))"#.to_string());
+    profile.push(r#"(allow file-write* (subpath "/tmp"))"#.to_string());
+    profile.push(r#"(allow file-write* (subpath "/private/var/folders"))"#.to_string());
+
+    // Network
+    if config.allow_network {
+        profile.push("(allow network*)".to_string());
+    } else {
+        profile.push("(allow network* (remote ip \"localhost:*\"))".to_string());
+        profile.push("(allow network* (local ip \"localhost:*\"))".to_string());
+    }
+
+    profile.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_profile() {
+        let config = SandboxConfig {
+            mountpoint: PathBuf::from("/Users/test/.agentfs/run/abc/mnt"),
+            allow_paths: vec![],
+            allow_read_paths: vec![],
+            allow_network: false,
+            session_id: "test123".to_string(),
+        };
+
+        let profile = generate_sandbox_profile(&config);
+
+        assert!(profile.contains("(version 1)"));
+        assert!(profile.contains("(deny default"));
+        assert!(profile.contains("agentfs-test123: write denied"));
+        assert!(profile.contains("/Users/test/.agentfs/run/abc/mnt"));
+    }
+
+    #[test]
+    fn test_profile_with_network() {
+        let config = SandboxConfig {
+            mountpoint: PathBuf::from("/mnt"),
+            allow_network: true,
+            ..Default::default()
+        };
+
+        let profile = generate_sandbox_profile(&config);
+        assert!(profile.contains("(allow network*)"));
+    }
+
+    #[test]
+    fn test_profile_with_custom_paths() {
+        let config = SandboxConfig {
+            mountpoint: PathBuf::from("/mnt"),
+            allow_paths: vec![PathBuf::from("/custom/writable")],
+            allow_read_paths: vec![PathBuf::from("/custom/readonly")],
+            ..Default::default()
+        };
+
+        let profile = generate_sandbox_profile(&config);
+        // Writable paths should be included
+        assert!(profile.contains("/custom/writable"));
+        // Note: allow_read_paths is not used since we allow all reads by default
+    }
+}


### PR DESCRIPTION
On macOS, agentfs run now uses Apple's Sandbox (sandbox-exec) with a dynamically generated profile for kernel-enforced filesystem isolation.