### PR TITLE
agentfs run: Default to bash on Linux, zsh on macOS

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
             command,
             args,
         } => {
+            let command = command.unwrap_or_else(default_shell);
             let rt = get_runtime();
             if let Err(e) = rt.block_on(cmd::handle_run_command(
                 allow,
@@ -131,3 +132,16 @@ fn reset_sigpipe() {
 
 #[cfg(not(unix))]
 fn reset_sigpipe() {}
+
+/// Returns the default shell for the current platform.
+/// Linux uses bash, macOS uses zsh.
+fn default_shell() -> std::path::PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        std::path::PathBuf::from("zsh")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::path::PathBuf::from("bash")
+    }
+}

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -69,8 +69,8 @@ pub enum Command {
         #[arg(long = "session", value_name = "ID")]
         session: Option<String>,
 
-        /// Command to execute
-        command: PathBuf,
+        /// Command to execute (defaults to bash on Linux, zsh on macOS)
+        command: Option<PathBuf>,
 
         /// Arguments for the command
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]


### PR DESCRIPTION
Make the command argument optional for `agentfs run`. When no command is specified, default to bash on Linux and zsh on macOS.