### PR TITLE
Add hard link support across Rust SDK, sandbox, and FUSE

### DIFF
--- a/cli/tests/syscall/Makefile
+++ b/cli/tests/syscall/Makefile
@@ -15,7 +15,8 @@ SRCS = main.c \
        test-lstat.c \
        test-getdents64.c \
        test-append.c \
-       test-pread-sparse.c
+       test-pread-sparse.c \
+       test-link.c
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/cli/tests/syscall/main.c
+++ b/cli/tests/syscall/main.c
@@ -31,6 +31,7 @@ int main(int argc, char *argv[]) {
         {"append_existing", test_append_existing},
         {"pwrite_nested", test_pwrite_nested},
         {"pread_sparse", test_pread_sparse},
+        {"link", test_link},
     };
 
     int num_tests = sizeof(tests) / sizeof(tests[0]);

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -48,5 +48,6 @@ int test_getdents64(const char *base_path);
 int test_append_existing(const char *base_path);
 int test_pwrite_nested(const char *base_path);
 int test_pread_sparse(const char *base_path);
+int test_link(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/cli/tests/syscall/test-link.c
+++ b/cli/tests/syscall/test-link.c
@@ -1,0 +1,109 @@
+#define _GNU_SOURCE
+#include "test-common.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int test_link(const char *base_path) {
+    char path[512], link_path[512], link_path2[512];
+    struct stat st_orig, st_link;
+    int result, fd;
+
+    snprintf(path, sizeof(path), "%s/test.txt", base_path);
+    snprintf(link_path, sizeof(link_path), "%s/test_hardlink", base_path);
+    snprintf(link_path2, sizeof(link_path2), "%s/test_hardlink2", base_path);
+
+    /* Clean up any previous test files */
+    unlink(link_path);
+    unlink(link_path2);
+
+    /* Test 1: Create a hard link to an existing file */
+    result = link(path, link_path);
+
+    /* Skip link tests if link syscall is not supported */
+    if (result < 0 && (errno == ENOSYS || errno == EOPNOTSUPP)) {
+        printf("  (Skipping hard link tests - syscall not supported)\n");
+        return 0;
+    }
+    TEST_ASSERT_ERRNO(result == 0, "link creation should succeed");
+
+    /* Test 2: Verify hard link shares the same inode */
+    result = stat(path, &st_orig);
+    TEST_ASSERT_ERRNO(result == 0, "stat on original should succeed");
+
+    result = stat(link_path, &st_link);
+    TEST_ASSERT_ERRNO(result == 0, "stat on hard link should succeed");
+
+    TEST_ASSERT(st_orig.st_ino == st_link.st_ino, "hard link should share inode with original");
+    TEST_ASSERT(S_ISREG(st_link.st_mode), "hard link should be a regular file");
+
+    /* Test 3: Verify link count is correct (at least 2) */
+    TEST_ASSERT(st_link.st_nlink >= 2, "nlink should be at least 2 after creating hard link");
+
+    /* Test 4: Verify data is shared - write through hard link, read from original */
+    fd = open(link_path, O_WRONLY | O_TRUNC);
+    TEST_ASSERT_ERRNO(fd >= 0, "open hard link for writing should succeed");
+    result = write(fd, "modified", 8);
+    TEST_ASSERT_ERRNO(result == 8, "write through hard link should succeed");
+    close(fd);
+
+    /* Read from original file */
+    char buf[16] = {0};
+    fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open original file for reading should succeed");
+    result = read(fd, buf, sizeof(buf) - 1);
+    TEST_ASSERT_ERRNO(result == 8, "read from original should succeed");
+    TEST_ASSERT(memcmp(buf, "modified", 8) == 0, "data written via hard link should be visible in original");
+    close(fd);
+
+    /* Test 5: Create another hard link */
+    result = link(path, link_path2);
+    TEST_ASSERT_ERRNO(result == 0, "creating second hard link should succeed");
+
+    result = stat(path, &st_orig);
+    TEST_ASSERT_ERRNO(result == 0, "stat on original after second link should succeed");
+    TEST_ASSERT(st_orig.st_nlink >= 3, "nlink should be at least 3 after second hard link");
+
+    /* Test 6: Remove one hard link, verify others still work */
+    result = unlink(link_path);
+    TEST_ASSERT_ERRNO(result == 0, "unlink first hard link should succeed");
+
+    result = stat(path, &st_orig);
+    TEST_ASSERT_ERRNO(result == 0, "original should still exist after unlinking hard link");
+    TEST_ASSERT(st_orig.st_nlink >= 2, "nlink should be at least 2 after removing one link");
+
+    /* Test 7: link to non-existent file should fail */
+    result = link("/nonexistent/file", link_path);
+    TEST_ASSERT(result < 0, "link to non-existent file should fail");
+    TEST_ASSERT(errno == ENOENT, "errno should be ENOENT for non-existent source");
+
+    /* Test 8: link to existing destination should fail */
+    result = link(path, link_path2);
+    TEST_ASSERT(result < 0, "link to existing destination should fail");
+    TEST_ASSERT(errno == EEXIST, "errno should be EEXIST for existing destination");
+
+    /* Test 9: Verify hard link to directory fails (if we have a directory to test with) */
+    char dir_path[512];
+    snprintf(dir_path, sizeof(dir_path), "%s/subdir", base_path);
+
+    /* Try to create the directory if it doesn't exist */
+    mkdir(dir_path, 0755);
+
+    result = link(dir_path, link_path);
+    if (result < 0) {
+        TEST_ASSERT(errno == EPERM || errno == EISDIR || errno == ENOENT,
+                   "link to directory should fail with EPERM, EISDIR, or ENOENT");
+    }
+
+    /* Clean up */
+    unlink(link_path2);
+
+    /* Restore original file content for other tests */
+    fd = open(path, O_WRONLY | O_TRUNC);
+    if (fd >= 0) {
+        write(fd, "test content\n", 13);
+        close(fd);
+    }
+
+    return 0;
+}

--- a/sandbox/src/syscall/mod.rs
+++ b/sandbox/src/syscall/mod.rs
@@ -220,6 +220,13 @@ pub async fn dispatch_syscall<T: Guest<Sandbox>>(
                 Ok(SyscallResult::Syscall(syscall))
             }
         }
+        Syscall::Linkat(args) => {
+            if let Some(result) = stat::handle_linkat(guest, args, mount_table, fd_table).await? {
+                Ok(SyscallResult::Value(result))
+            } else {
+                Ok(SyscallResult::Syscall(syscall))
+            }
+        }
         Syscall::Llistxattr(args) => {
             if let Some(modified) = xattr::handle_llistxattr(guest, args, mount_table).await? {
                 Ok(SyscallResult::Syscall(modified))

--- a/sandbox/src/syscall/stat.rs
+++ b/sandbox/src/syscall/stat.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use reverie::{
     syscalls::{MemoryAccess, ReadAddr, Syscall},
-    Error, Guest,
+    Error, Guest, Stack,
 };
 
 /// The `statx` system call.
@@ -405,6 +405,148 @@ pub async fn handle_symlinkat<T: Guest<Sandbox>>(
 
                 let result = guest.inject(Syscall::Symlinkat(new_syscall)).await?;
                 return Ok(Some(result));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// The `linkat` system call.
+///
+/// This intercepts `linkat` system calls and translates paths according to the mount table
+/// and virtualizes the dirfds.
+/// Returns `Some(result)` if the syscall was handled and the result should be returned directly,
+/// or `None` if the original syscall should be used.
+pub async fn handle_linkat<T: Guest<Sandbox>>(
+    guest: &mut T,
+    args: &reverie::syscalls::Linkat,
+    mount_table: &MountTable,
+    fd_table: &FdTable,
+) -> Result<Option<i64>, Error> {
+    let olddirfd = args.olddirfd();
+    let newdirfd = args.newdirfd();
+
+    // AT_FDCWD is -100
+    let kernel_olddirfd = if olddirfd == -100 {
+        olddirfd
+    } else {
+        fd_table.translate(olddirfd).unwrap_or(olddirfd)
+    };
+    let kernel_newdirfd = if newdirfd == -100 {
+        newdirfd
+    } else {
+        fd_table.translate(newdirfd).unwrap_or(newdirfd)
+    };
+
+    // Read oldpath and newpath from guest memory
+    if let Some(oldpath_addr) = args.oldpath() {
+        let oldpath: std::path::PathBuf = oldpath_addr.read(&guest.memory())?;
+
+        if let Some(newpath_addr) = args.newpath() {
+            let newpath: std::path::PathBuf = newpath_addr.read(&guest.memory())?;
+
+            // Check if newpath matches a mount point with virtual VFS
+            if let Some((vfs, _translated_path)) = mount_table.resolve(&newpath) {
+                // Check if this is a virtual VFS (like SQLite)
+                if vfs.is_virtual() {
+                    // Call VFS link method directly
+                    match vfs.link(&oldpath, &newpath).await {
+                        Ok(()) => return Ok(Some(0)), // Success
+                        Err(e) => {
+                            // Map VFS errors to errno
+                            let errno = match e {
+                                crate::vfs::VfsError::NotFound => -libc::ENOENT as i64,
+                                crate::vfs::VfsError::PermissionDenied => -libc::EPERM as i64,
+                                crate::vfs::VfsError::AlreadyExists => -libc::EEXIST as i64,
+                                _ => -libc::EIO as i64,
+                            };
+                            return Ok(Some(errno));
+                        }
+                    }
+                }
+            }
+
+            // Check if either path needs translation by consulting the mount table.
+            // We resolve both paths first (without guest memory allocation) to determine
+            // what needs translation, then allocate and inject if needed.
+            let oldpath_translated = mount_table.resolve(&oldpath);
+            let newpath_translated = mount_table.resolve(&newpath);
+
+            match (oldpath_translated, newpath_translated) {
+                (Some((_vfs1, translated_oldpath)), Some((_vfs2, translated_newpath))) => {
+                    // Both paths need translation
+                    use std::ffi::CString;
+
+                    let old_cstr =
+                        CString::new(translated_oldpath.to_string_lossy().to_string())
+                            .map_err(|_| reverie::syscalls::Errno::EINVAL)?;
+                    let new_cstr =
+                        CString::new(translated_newpath.to_string_lossy().to_string())
+                            .map_err(|_| reverie::syscalls::Errno::EINVAL)?;
+
+                    // Allocate space for both paths on guest stack
+                    let old_bytes = old_cstr.as_bytes_with_nul();
+                    let new_bytes = new_cstr.as_bytes_with_nul();
+
+                    let mut stack = guest.stack().await;
+                    let old_addr: reverie::syscalls::AddrMut<std::path::PathBuf> = stack.reserve();
+                    let new_addr: reverie::syscalls::AddrMut<std::path::PathBuf> = stack.reserve();
+                    stack.commit()?;
+
+                    let old_byte_addr = old_addr.cast::<u8>();
+                    let new_byte_addr = new_addr.cast::<u8>();
+                    guest.memory().write_exact(old_byte_addr, old_bytes)?;
+                    guest.memory().write_exact(new_byte_addr, new_bytes)?;
+
+                    let new_oldpath_ptr: reverie::syscalls::PathPtr = unsafe {
+                        std::mem::transmute(old_byte_addr)
+                    };
+                    let new_newpath_ptr: reverie::syscalls::PathPtr = unsafe {
+                        std::mem::transmute(new_byte_addr)
+                    };
+
+                    let new_syscall = reverie::syscalls::Linkat::new()
+                        .with_olddirfd(kernel_olddirfd)
+                        .with_oldpath(Some(new_oldpath_ptr))
+                        .with_newdirfd(kernel_newdirfd)
+                        .with_newpath(Some(new_newpath_ptr))
+                        .with_flags(args.flags());
+                    let result = guest.inject(Syscall::Linkat(new_syscall)).await?;
+                    return Ok(Some(result));
+                }
+                (Some(_), None) => {
+                    // Only oldpath needs translation
+                    if let Some(new_oldpath_addr) =
+                        translate_path(guest, oldpath_addr, mount_table).await?
+                    {
+                        let new_syscall = reverie::syscalls::Linkat::new()
+                            .with_olddirfd(kernel_olddirfd)
+                            .with_oldpath(Some(new_oldpath_addr))
+                            .with_newdirfd(kernel_newdirfd)
+                            .with_newpath(Some(newpath_addr))
+                            .with_flags(args.flags());
+                        let result = guest.inject(Syscall::Linkat(new_syscall)).await?;
+                        return Ok(Some(result));
+                    }
+                }
+                (None, Some(_)) => {
+                    // Only newpath needs translation
+                    if let Some(new_newpath_addr) =
+                        translate_path(guest, newpath_addr, mount_table).await?
+                    {
+                        let new_syscall = reverie::syscalls::Linkat::new()
+                            .with_olddirfd(kernel_olddirfd)
+                            .with_oldpath(Some(oldpath_addr))
+                            .with_newdirfd(kernel_newdirfd)
+                            .with_newpath(Some(new_newpath_addr))
+                            .with_flags(args.flags());
+                        let result = guest.inject(Syscall::Linkat(new_syscall)).await?;
+                        return Ok(Some(result));
+                    }
+                }
+                (None, None) => {
+                    // Neither path needs translation
+                }
             }
         }
     }

--- a/sandbox/src/vfs/mod.rs
+++ b/sandbox/src/vfs/mod.rs
@@ -111,6 +111,16 @@ pub trait Vfs: Send + Sync {
             "readlink() not supported by this VFS".to_string(),
         ))
     }
+
+    /// Create a hard link (for virtual filesystems)
+    ///
+    /// Creates a new directory entry `newpath` that refers to the same inode as `oldpath`.
+    /// This is only called for virtual VFS implementations.
+    async fn link(&self, _oldpath: &Path, _newpath: &Path) -> VfsResult<()> {
+        Err(VfsError::Other(
+            "link() not supported by this VFS".to_string(),
+        ))
+    }
 }
 
 /// A boxed VFS trait object for dynamic dispatch

--- a/sdk/rust/src/filesystem/hostfs.rs
+++ b/sdk/rust/src/filesystem/hostfs.rs
@@ -257,6 +257,13 @@ impl FileSystem for HostFS {
         Ok(())
     }
 
+    async fn link(&self, oldpath: &str, newpath: &str) -> Result<()> {
+        let old_full_path = self.resolve_path(oldpath);
+        let new_full_path = self.resolve_path(newpath);
+        tokio::fs::hard_link(&old_full_path, &new_full_path).await?;
+        Ok(())
+    }
+
     async fn readlink(&self, path: &str) -> Result<Option<String>> {
         let full_path = self.resolve_path(path);
         match fs::read_link(&full_path).await {

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -196,6 +196,13 @@ pub trait FileSystem: Send + Sync {
     /// Create a symbolic link
     async fn symlink(&self, target: &str, linkpath: &str) -> Result<()>;
 
+    /// Create a hard link
+    ///
+    /// Creates a new directory entry `newpath` that refers to the same inode as `oldpath`.
+    /// Both paths will share the same file data and metadata (except for the name).
+    /// The link count (nlink) of the inode is incremented.
+    async fn link(&self, oldpath: &str, newpath: &str) -> Result<()>;
+
     /// Read the target of a symbolic link
     ///
     /// Returns `Ok(None)` if the path does not exist.


### PR DESCRIPTION
Implement the linkat syscall and link() filesystem operation to enable hard links in AgentFS. This fixes the cargo incremental compilation warning about hard linking files failing.