### PR TITLE
Add `agentfs ps` and `agentfs mount` listing commands

### DIFF
--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -1,12 +1,13 @@
 pub mod completions;
 pub mod fs;
 pub mod init;
+pub mod ps;
 
 #[cfg(target_os = "linux")]
-mod mount;
+pub mod mount;
 #[cfg(not(target_os = "linux"))]
 #[path = "mount_stub.rs"]
-mod mount;
+pub mod mount;
 
 // Run module selection:
 // - Linux x86_64: use overlay sandbox (run.rs)

--- a/cli/src/cmd/mount.rs
+++ b/cli/src/cmd/mount.rs
@@ -1,9 +1,55 @@
-use agentfs_sdk::{AgentFS, AgentFSOptions, FileSystem, HostFS, OverlayFS};
+use agentfs_sdk::{get_mounted_agents, AgentFS, AgentFSOptions, FileSystem, HostFS, OverlayFS};
 use anyhow::Result;
-use std::{os::unix::fs::MetadataExt, path::PathBuf, sync::Arc};
+use std::{io::Write, os::unix::fs::MetadataExt, path::PathBuf, sync::Arc};
 use turso::Value;
 
 use crate::fuse::FuseMountOptions;
+
+/// List all currently mounted agentfs filesystems
+pub fn list_mounts<W: Write>(out: &mut W) {
+    let mounts = get_mounted_agents();
+
+    if mounts.is_empty() {
+        let _ = writeln!(out, "No agentfs filesystems mounted.");
+        return;
+    }
+
+    // Calculate column widths
+    let id_width = mounts
+        .iter()
+        .map(|m| m.agent_id.len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let mount_width = mounts
+        .iter()
+        .map(|m| m.mountpoint.to_string_lossy().len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+
+    // Print header
+    let _ = writeln!(
+        out,
+        "{:<id_width$}  {:<mount_width$}",
+        "AGENT ID",
+        "MOUNTPOINT",
+        id_width = id_width,
+        mount_width = mount_width
+    );
+
+    // Print mounts
+    for mount in &mounts {
+        let _ = writeln!(
+            out,
+            "{:<id_width$}  {:<mount_width$}",
+            mount.agent_id,
+            mount.mountpoint.display(),
+            id_width = id_width,
+            mount_width = mount_width
+        );
+    }
+}
 
 /// Arguments for the mount command.
 #[derive(Debug, Clone)]

--- a/cli/src/cmd/mount_stub.rs
+++ b/cli/src/cmd/mount_stub.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::io::Write;
 use std::path::PathBuf;
 
 /// Arguments for the mount command.
@@ -24,4 +25,9 @@ pub struct MountArgs {
 /// Mount the agent filesystem using FUSE.
 pub fn mount(_args: MountArgs) -> Result<()> {
     anyhow::bail!("FUSE mount is only available on Linux")
+}
+
+/// List all currently mounted agentfs filesystems
+pub fn list_mounts<W: Write>(out: &mut W) {
+    let _ = writeln!(out, "Listing mounts is only available on Linux.");
 }

--- a/cli/src/cmd/ps.rs
+++ b/cli/src/cmd/ps.rs
@@ -1,0 +1,129 @@
+use agentfs_sdk::get_mounted_agents;
+use anyhow::Result;
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Get the run directory for agentfs sandbox sessions
+fn run_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".agentfs")
+        .join("run")
+}
+
+/// Information about a sandbox session
+struct SessionInfo {
+    id: String,
+    mountpoint: Option<String>,
+}
+
+/// List sandbox sessions
+pub async fn ps<W: Write>(out: &mut W, show_all: bool) -> Result<()> {
+    let run_dir = run_dir();
+
+    // Get currently mounted agents from /proc/mounts (authoritative source)
+    let mounted: HashSet<String> = get_mounted_agents()
+        .into_iter()
+        .map(|m| m.agent_id)
+        .collect();
+
+    // Collect session info from ~/.agentfs/run/
+    let mut sessions: Vec<SessionInfo> = Vec::new();
+
+    if run_dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&run_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+
+                // Only look at directories that contain a delta.db file
+                if path.is_dir() {
+                    let delta_db = path.join("delta.db");
+                    if delta_db.exists() {
+                        if let Some(session_id) = path.file_name().and_then(|s| s.to_str()) {
+                            let session_id = session_id.to_string();
+
+                            // Check if this session is currently mounted
+                            let mountpoint = if mounted.contains(&session_id) {
+                                Some(path.join("mnt").to_string_lossy().to_string())
+                            } else {
+                                None
+                            };
+
+                            sessions.push(SessionInfo {
+                                id: session_id,
+                                mountpoint,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Filter to only running sessions unless -a flag is set
+    if !show_all {
+        sessions.retain(|s| s.mountpoint.is_some());
+    }
+
+    // Sort by session ID
+    sessions.sort_by(|a, b| a.id.cmp(&b.id));
+
+    if sessions.is_empty() {
+        if show_all {
+            writeln!(out, "No sandbox sessions found in {}", run_dir.display())?;
+        } else {
+            writeln!(
+                out,
+                "No running sandbox sessions. Use -a to show all sessions."
+            )?;
+        }
+        return Ok(());
+    }
+
+    // Calculate column widths
+    let id_width = sessions
+        .iter()
+        .map(|s| s.id.len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+    let mount_width = sessions
+        .iter()
+        .map(|s| s.mountpoint.as_ref().map(|m| m.len()).unwrap_or(1))
+        .max()
+        .unwrap_or(10)
+        .max(10);
+
+    // Print header
+    writeln!(
+        out,
+        "{:<id_width$}  {:<mount_width$}  STATUS",
+        "SESSION ID",
+        "MOUNTPOINT",
+        id_width = id_width,
+        mount_width = mount_width
+    )?;
+
+    // Print sessions
+    for session in &sessions {
+        let mountpoint = session.mountpoint.as_deref().unwrap_or("-");
+        let status = if session.mountpoint.is_some() {
+            "running"
+        } else {
+            "stopped"
+        };
+
+        writeln!(
+            out,
+            "{:<id_width$}  {:<mount_width$}  {}",
+            session.id,
+            mountpoint,
+            status,
+            id_width = id_width,
+            mount_width = mount_width
+        )?;
+    }
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,20 +61,29 @@ fn main() {
             foreground,
             uid,
             gid,
-        } => {
-            if let Err(e) = cmd::mount(cmd::MountArgs {
-                id_or_path,
-                mountpoint,
-                auto_unmount,
-                allow_root,
-                foreground,
-                uid,
-                gid,
-            }) {
-                eprintln!("Error: {}", e);
+        } => match (id_or_path, mountpoint) {
+            (Some(id_or_path), Some(mountpoint)) => {
+                if let Err(e) = cmd::mount(cmd::MountArgs {
+                    id_or_path,
+                    mountpoint,
+                    auto_unmount,
+                    allow_root,
+                    foreground,
+                    uid,
+                    gid,
+                }) {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            (None, None) => {
+                cmd::mount::list_mounts(&mut std::io::stdout());
+            }
+            _ => {
+                eprintln!("Error: both ID_OR_PATH and MOUNTPOINT are required to mount");
                 std::process::exit(1);
             }
-        }
+        },
         Command::Diff { id_or_path } => {
             let rt = get_runtime();
             if let Err(e) = rt.block_on(cmd::fs::diff_filesystem(id_or_path)) {
@@ -114,6 +123,13 @@ fn main() {
             }
         }
         Command::Completions { command } => handle_completions(command),
+        Command::Ps { all } => {
+            let rt = get_runtime();
+            if let Err(e) = rt.block_on(cmd::ps::ps(&mut std::io::stdout(), all)) {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
         #[cfg(unix)]
         Command::Nfs {
             id_or_path,

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -76,15 +76,15 @@ pub enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Mount an agent filesystem using FUSE
+    /// Mount an agent filesystem using FUSE (or list mounts if no args)
     Mount {
-        /// Agent ID or database path
+        /// Agent ID or database path (if omitted, lists current mounts)
         #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
-        id_or_path: String,
+        id_or_path: Option<String>,
 
         /// Mount point directory
         #[arg(value_name = "MOUNTPOINT", add = ArgValueCompleter::new(PathCompleter::dir()))]
-        mountpoint: PathBuf,
+        mountpoint: Option<PathBuf>,
 
         /// Automatically unmount on exit
         #[arg(short = 'a', long)]
@@ -111,6 +111,12 @@ pub enum Command {
         /// Agent ID or database path
         #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
         id_or_path: String,
+    },
+    /// List sandbox sessions (from `agentfs run`)
+    Ps {
+        /// Show all sessions (including those not currently running)
+        #[arg(short = 'a', long)]
+        all: bool,
     },
     /// Start an NFS server to export an AgentFS filesystem over the network
     #[cfg(unix)]

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -25,6 +25,53 @@ pub fn agentfs_dir() -> &'static std::path::Path {
     std::path::Path::new(".agentfs")
 }
 
+/// Information about a mounted agentfs filesystem
+#[derive(Debug, Clone)]
+pub struct MountedAgent {
+    /// The agent ID (from the mount source, e.g., "agentfs:my-agent" -> "my-agent")
+    pub agent_id: String,
+    /// The mountpoint path
+    pub mountpoint: PathBuf,
+}
+
+/// Get all currently mounted agentfs filesystems by parsing /proc/mounts
+///
+/// This is the authoritative source for mount information - if it's in /proc/mounts,
+/// it's mounted. If not, it's not. No stale state possible.
+#[cfg(target_os = "linux")]
+pub fn get_mounted_agents() -> Vec<MountedAgent> {
+    let Ok(contents) = std::fs::read_to_string("/proc/mounts") else {
+        return vec![];
+    };
+    contents
+        .lines()
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 && parts[0].starts_with("agentfs:") {
+                let agent_id = parts[0].strip_prefix("agentfs:")?.to_string();
+                // Skip the internal "fuse" mount used by the daemon
+                if agent_id == "fuse" {
+                    return None;
+                }
+                Some(MountedAgent {
+                    agent_id,
+                    mountpoint: PathBuf::from(parts[1]),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Get all currently mounted agentfs filesystems (non-Linux stub)
+#[cfg(not(target_os = "linux"))]
+pub fn get_mounted_agents() -> Vec<MountedAgent> {
+    // On macOS, we could parse the output of `mount` command
+    // For now, return empty - can be implemented later
+    vec![]
+}
+
 /// Configuration options for opening an AgentFS instance
 #[derive(Debug, Clone, Default)]
 pub struct AgentFSOptions {


### PR DESCRIPTION
Add `agentfs ps` and `agentfs mount` listing commands:

- `agentfs ps` lists sandbox sessions from ~/.agentfs/run/
- `agentfs ps -a` includes stopped sessions
- `agentfs mount` (no args) lists all FUSE mount points

Mount status is determined by parsing /proc/mounts directly, which is the authoritative source. 