### PR TITLE
agentfs: Enable local file locking on macOS

### DIFF
--- a/cli/src/cmd/run_darwin.rs
+++ b/cli/src/cmd/run_darwin.rs
@@ -247,7 +247,7 @@ fn mount_nfs(port: u32, mountpoint: &Path) -> Result<()> {
         .args([
             "-o",
             &format!(
-                "nolocks,vers=3,tcp,port={},mountport={},soft,timeo=10,retrans=2",
+                "locallocks,vers=3,tcp,port={},mountport={},soft,timeo=10,retrans=2",
                 port, port
             ),
             &format!("127.0.0.1:/"),


### PR DESCRIPTION
Change NFS mount option from `nolocks` to `locallocks` to enable client-side file locking. This fixes Rust incremental compilation which requires file locking support.

Fixes #195