### PR TITLE
Add `agentfs mount` command to list all mounted filesystems

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -155,28 +155,42 @@ The `.agentfs/` directory is automatically created if it doesn't exist.
 
 ### `agentfs mount`
 
-Mount an agent filesystem using FUSE (Linux) or NFS (macOS).
+Mount an agent filesystem using FUSE (Linux) or NFS (macOS), or list currently mounted filesystems.
 
 **Usage:**
 ```bash
-agentfs mount <ID_OR_PATH> <MOUNT_POINT>
+agentfs mount [ID_OR_PATH] [MOUNT_POINT]
 ```
 
 **Arguments:**
-- `<ID_OR_PATH>` - Agent ID or database path
-- `<MOUNT_POINT>` - Directory where the filesystem will be mounted
+- `[ID_OR_PATH]` - Agent ID or database path (optional)
+- `[MOUNT_POINT]` - Directory where the filesystem will be mounted (optional)
+
+When called without arguments, lists all currently mounted agentfs filesystems.
 
 **Options:**
 - `-h, --help` - Print help
 
 **Examples:**
 ```bash
+# List all mounted agentfs filesystems
+agentfs mount
+
 # Mount using agent ID
 agentfs mount my-agent ./my-agent-mount
 
 # Mount using database path
 agentfs mount .agentfs/my-agent.db ./my-agent-mount
 ```
+
+**Listing output:**
+```
+ID        MOUNTPOINT
+my-agent  /home/user/my-agent-mount
+other     /tmp/other-mount
+```
+
+If no filesystems are mounted, displays "No agentfs filesystems mounted."
 
 **What it does:**
 Mounts the agent filesystem as a FUSE filesystem on the host, allowing you to interact with the agent's files using standard filesystem tools (ls, cat, cp, etc.).

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -6,10 +6,10 @@ pub mod sync;
 pub mod timeline;
 
 #[cfg(target_os = "linux")]
-mod mount;
+pub mod mount;
 #[cfg(not(target_os = "linux"))]
 #[path = "mount_stub.rs"]
-mod mount;
+pub mod mount;
 
 mod run;
 

--- a/cli/src/cmd/mount_stub.rs
+++ b/cli/src/cmd/mount_stub.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::path::PathBuf;
+use std::{io::Write, path::PathBuf};
 
 /// Arguments for the mount command.
 #[derive(Debug, Clone)]
@@ -19,6 +19,11 @@ pub struct MountArgs {
     pub uid: Option<u32>,
     /// Group ID to report for all files (defaults to current group).
     pub gid: Option<u32>,
+}
+
+/// List all currently mounted agentfs filesystems
+pub fn list_mounts<W: Write>(out: &mut W) {
+    let _ = writeln!(out, "Mount listing is only available on Linux.");
 }
 
 /// Mount the agent filesystem using FUSE.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,20 +102,29 @@ fn main() {
             foreground,
             uid,
             gid,
-        } => {
-            if let Err(e) = cmd::mount(cmd::MountArgs {
-                id_or_path,
-                mountpoint,
-                auto_unmount,
-                allow_root,
-                foreground,
-                uid,
-                gid,
-            }) {
-                eprintln!("Error: {}", e);
+        } => match (id_or_path, mountpoint) {
+            (Some(id_or_path), Some(mountpoint)) => {
+                if let Err(e) = cmd::mount(cmd::MountArgs {
+                    id_or_path,
+                    mountpoint,
+                    auto_unmount,
+                    allow_root,
+                    foreground,
+                    uid,
+                    gid,
+                }) {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            (None, None) => {
+                cmd::mount::list_mounts(&mut std::io::stdout());
+            }
+            _ => {
+                eprintln!("Error: both ID_OR_PATH and MOUNTPOINT are required to mount");
                 std::process::exit(1);
             }
-        }
+        },
         Command::Diff { id_or_path } => {
             let rt = get_runtime();
             if let Err(e) = rt.block_on(cmd::fs::diff_filesystem(id_or_path)) {

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -106,15 +106,15 @@ pub enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Mount an agent filesystem using FUSE
+    /// Mount an agent filesystem using FUSE (or list mounts if no args)
     Mount {
-        /// Agent ID or database path
+        /// Agent ID or database path (if omitted, lists current mounts)
         #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
-        id_or_path: String,
+        id_or_path: Option<String>,
 
         /// Mount point directory
         #[arg(value_name = "MOUNTPOINT", add = ArgValueCompleter::new(PathCompleter::dir()))]
-        mountpoint: PathBuf,
+        mountpoint: Option<PathBuf>,
 
         /// Automatically unmount on exit
         #[arg(short = 'a', long)]

--- a/cli/tests/test-mount.sh
+++ b/cli/tests/test-mount.sh
@@ -48,6 +48,13 @@ if ! mountpoint -q "$MOUNTPOINT" 2>/dev/null; then
     exit 1
 fi
 
+# Test that 'agentfs mount' (no args) lists our mount
+if ! cargo run -- mount 2>/dev/null | grep -q "$MOUNTPOINT"; then
+    echo "FAILED: 'agentfs mount' did not list our mountpoint"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
 # Write a file through the FUSE mount
 echo "hello from fuse mount" > "$MOUNTPOINT/hello.txt"
 


### PR DESCRIPTION
When called without arguments, `agentfs mount` now lists all currently mounted agentfs filesystems by parsing /proc/mounts. The existing mount functionality remains available when both ID_OR_PATH and MOUNTPOINT are provided.