### PR TITLE
Add `agentfs serve` command for NFS and MCP servers

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ libc = "0.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 fuser = { version = "0.15", default-features = false, features = ["abi-7-29"] }
 uuid = { version = "1", features = ["v4"] }
-# NFS server for userspace filesystem (used by `agentfs run` and `agentfs nfs`)
+# NFS server for userspace filesystem (used by `agentfs run` and `agentfs serve nfs`)
 nfsserve = "0.10"
 async-trait = "0.1"
 # Sandbox dependencies - (requires libunwind-dev on ARM)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use agentfs::{
     cmd::{self, completions::handle_completions},
     get_runtime,
-    parser::{Args, Command, FsCommand, SyncCommand},
+    parser::{Args, Command, FsCommand, ServeCommand, SyncCommand},
 };
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -198,6 +198,7 @@ fn main() {
             bind,
             port,
         } => {
+            eprintln!("Warning: `agentfs nfs` is deprecated, use `agentfs serve nfs` instead");
             let rt = get_runtime();
             if let Err(e) = rt.block_on(cmd::nfs::handle_nfs_command(id_or_path, bind, port)) {
                 eprintln!("Error: {}", e);
@@ -205,6 +206,9 @@ fn main() {
             }
         }
         Command::McpServer { id_or_path, tools } => {
+            eprintln!(
+                "Warning: `agentfs mcp-server` is deprecated, use `agentfs serve mcp` instead"
+            );
             let rt = get_runtime();
             if let Err(e) = rt.block_on(cmd::mcp_server::handle_mcp_server_command(
                 id_or_path, tools,
@@ -213,6 +217,29 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Command::Serve { command } => match command {
+            #[cfg(unix)]
+            ServeCommand::Nfs {
+                id_or_path,
+                bind,
+                port,
+            } => {
+                let rt = get_runtime();
+                if let Err(e) = rt.block_on(cmd::nfs::handle_nfs_command(id_or_path, bind, port)) {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            ServeCommand::Mcp { id_or_path, tools } => {
+                let rt = get_runtime();
+                if let Err(e) = rt.block_on(cmd::mcp_server::handle_mcp_server_command(
+                    id_or_path, tools,
+                )) {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        },
     }
 }
 

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -165,6 +165,7 @@ pub enum Command {
         format: String,
     },
     /// Start an NFS server to export an AgentFS filesystem over the network
+    /// (deprecated: use `agentfs serve nfs` instead)
     #[cfg(unix)]
     Nfs {
         /// Agent ID or database path
@@ -181,6 +182,7 @@ pub enum Command {
     },
 
     /// Start an MCP server exposing filesystem and KV-store tools
+    /// (deprecated: use `agentfs serve mcp` instead)
     McpServer {
         /// Agent ID or database path
         #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
@@ -191,6 +193,12 @@ pub enum Command {
         /// copy_file, rename, stat, access, kv_get, kv_set, kv_delete, kv_list
         #[arg(long, value_delimiter = ',')]
         tools: Option<Vec<String>>,
+    },
+
+    /// Serve an AgentFS filesystem via different protocols
+    Serve {
+        #[command(subcommand)]
+        command: ServeCommand,
     },
 }
 
@@ -227,6 +235,38 @@ pub enum SyncCommand {
     Stats,
     /// Checkpoint local synced db
     Checkpoint,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ServeCommand {
+    /// Start an NFS server to export an AgentFS filesystem over the network
+    #[cfg(unix)]
+    Nfs {
+        /// Agent ID or database path
+        #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
+        id_or_path: String,
+
+        /// IP address to bind to
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+
+        /// Port to listen on
+        #[arg(long, default_value = "11111")]
+        port: u32,
+    },
+
+    /// Start an MCP server exposing filesystem and KV-store tools
+    Mcp {
+        /// Agent ID or database path
+        #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
+        id_or_path: String,
+
+        /// Tools to expose (comma-separated). If not provided, all tools are exposed.
+        /// Available tools: read_file, write_file, readdir, mkdir, rmdir, rm, unlink,
+        /// copy_file, rename, stat, access, kv_get, kv_set, kv_delete, kv_list
+        #[arg(long, value_delimiter = ',')]
+        tools: Option<Vec<String>>,
+    },
 }
 
 #[derive(Subcommand, Debug, Clone, Copy)]

--- a/examples/firecracker/firecracker.sh
+++ b/examples/firecracker/firecracker.sh
@@ -56,7 +56,7 @@ trap cleanup EXIT
 
 # Clean up from previous failed run
 sudo ip link del "${TAP_DEV}" 2>/dev/null || true
-pkill -f "agentfs nfs.*${NFS_PORT}" 2>/dev/null || true
+pkill -f "agentfs serve nfs.*${NFS_PORT}" 2>/dev/null || true
 sleep 0.5
 
 # Set up TAP device
@@ -66,7 +66,7 @@ sudo ip link set "${TAP_DEV}" up
 
 # Start agentfs NFS server (suppress output)
 cd "${SCRIPT_DIR}"
-${AGENTFS} nfs --bind "${TAP_IP}" --port "${NFS_PORT}" "${AGENT_ID}" >/dev/null 2>&1 &
+${AGENTFS} serve nfs --bind "${TAP_IP}" --port "${NFS_PORT}" "${AGENT_ID}" >/dev/null 2>&1 &
 AGENTFS_PID=$!
 sleep 1
 


### PR DESCRIPTION
Introduces a new `agentfs serve` subcommand that groups server-related functionality under a consistent CLI pattern:

- `agentfs serve nfs` - Start NFS server (was `agentfs nfs`)
- `agentfs serve mcp` - Start MCP server (was `agentfs mcp-server`)

The old commands are kept for backward compatibility but now print deprecation warnings directing users to the new commands.