### PR TITLE
Fix unlink() path cache invalidation in FUSE module

### DIFF
--- a/cli/tests/all.sh
+++ b/cli/tests/all.sh
@@ -16,5 +16,6 @@ DIR="$(dirname "$0")"
 "$DIR/test-run-syscalls.sh" || true  # Requires user namespaces (may fail in CI)
 
 "$DIR/test-run-bash.sh" || true  # Requires user namespaces (may fail in CI)
+"$DIR/test-run-git.sh" || true  # Requires user namespaces (may fail in CI)
 "$DIR/test-mount.sh"
 "$DIR/test-symlinks.sh" || true  # Requires user namespaces (may fail in CI)

--- a/cli/tests/syscall/Makefile
+++ b/cli/tests/syscall/Makefile
@@ -16,7 +16,8 @@ SRCS = main.c \
        test-getdents64.c \
        test-append.c \
        test-pread-sparse.c \
-       test-link.c
+       test-link.c \
+       test-unlink.c
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/cli/tests/syscall/main.c
+++ b/cli/tests/syscall/main.c
@@ -32,6 +32,7 @@ int main(int argc, char *argv[]) {
         {"pwrite_nested", test_pwrite_nested},
         {"pread_sparse", test_pread_sparse},
         {"link", test_link},
+        {"unlink", test_unlink},
     };
 
     int num_tests = sizeof(tests) / sizeof(tests[0]);

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -49,5 +49,6 @@ int test_append_existing(const char *base_path);
 int test_pwrite_nested(const char *base_path);
 int test_pread_sparse(const char *base_path);
 int test_link(const char *base_path);
+int test_unlink(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/cli/tests/syscall/test-unlink.c
+++ b/cli/tests/syscall/test-unlink.c
@@ -1,0 +1,68 @@
+#define _GNU_SOURCE
+#include "test-common.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int test_unlink(const char *base_path) {
+    char path[512], link_path[512];
+    struct stat st;
+    int result, fd;
+
+    snprintf(path, sizeof(path), "%s/unlink_test.txt", base_path);
+    snprintf(link_path, sizeof(link_path), "%s/unlink_test_link", base_path);
+
+    /* Clean up any previous test files */
+    unlink(link_path);
+    unlink(path);
+
+    /* Test 1: Create a file */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    TEST_ASSERT_ERRNO(fd >= 0, "create file should succeed");
+    result = write(fd, "test data", 9);
+    TEST_ASSERT_ERRNO(result == 9, "write should succeed");
+    close(fd);
+
+    /* Test 2: Create a hard link */
+    result = link(path, link_path);
+    if (result < 0 && (errno == ENOSYS || errno == EOPNOTSUPP)) {
+        printf("  (Skipping unlink path cache test - hard links not supported)\n");
+        unlink(path);
+        return 0;
+    }
+    TEST_ASSERT_ERRNO(result == 0, "link creation should succeed");
+
+    /* Test 3: Unlink the original file */
+    result = unlink(path);
+    TEST_ASSERT_ERRNO(result == 0, "unlink original should succeed");
+
+    /* Test 4: Access the hard link - this triggers the bug fixed in da06605
+     * Before the fix, the path cache was invalidated when unlinking,
+     * even though the hard link still references the same inode.
+     */
+    result = stat(link_path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on remaining hard link should succeed after unlink");
+    TEST_ASSERT(S_ISREG(st.st_mode), "hard link should still be a regular file");
+    TEST_ASSERT(st.st_nlink == 1, "nlink should be 1 after removing original");
+
+    /* Test 5: Read from the hard link */
+    char buf[16] = {0};
+    fd = open(link_path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open hard link for reading should succeed");
+    result = read(fd, buf, sizeof(buf) - 1);
+    TEST_ASSERT_ERRNO(result == 9, "read from hard link should succeed");
+    TEST_ASSERT(memcmp(buf, "test data", 9) == 0, "data should be intact via hard link");
+    close(fd);
+
+    /* Test 6: Write to the hard link */
+    fd = open(link_path, O_WRONLY | O_TRUNC);
+    TEST_ASSERT_ERRNO(fd >= 0, "open hard link for writing should succeed");
+    result = write(fd, "new data", 8);
+    TEST_ASSERT_ERRNO(result == 8, "write to hard link should succeed");
+    close(fd);
+
+    /* Clean up */
+    unlink(link_path);
+
+    return 0;
+}

--- a/cli/tests/test-run-git.sh
+++ b/cli/tests/test-run-git.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e
+
+echo -n "TEST git init and commit in overlay... "
+
+# Clean up any previous test directory
+rm -rf test-git-repo
+
+# Run git operations in overlay: init, add, commit
+output=$(cargo run -- run /bin/bash -c '
+mkdir test-git-repo
+cd test-git-repo
+git init
+echo "hello" > hello.txt
+git add hello.txt
+git commit -m "Initial commit"
+git log --oneline
+' 2>&1)
+
+# Verify we got a successful commit (git log shows commit hash and message)
+echo "$output" | grep -q "Initial commit" || {
+    echo "FAILED"
+    echo "$output"
+    exit 1
+}
+
+# Verify the directory was NOT written to the host (it's in the delta layer)
+if [ -d "test-git-repo" ]; then
+    echo "FAILED: test-git-repo should not exist on host filesystem"
+    rm -rf test-git-repo
+    exit 1
+fi
+
+echo "OK"


### PR DESCRIPTION
Let's not remove path from the path cache until it's the last link.