### PR TITLE
fix(gemini, amp): add .gemini, .amp to allow list

### DIFF
--- a/cli/src/cmd/run_darwin.rs
+++ b/cli/src/cmd/run_darwin.rs
@@ -171,6 +171,7 @@ struct RunSession {
 /// Default directories in HOME that are allowed to be writable.
 /// These are common application config/cache directories that many programs need.
 const DEFAULT_ALLOWED_DIRS: &[&str] = &[
+    ".amp",         // Amp config
     ".claude",      // Claude Code config
     ".claude.json", // Claude Code config file
     ".gemini",      // Gemini CLI config

--- a/cli/src/sandbox/linux.rs
+++ b/cli/src/sandbox/linux.rs
@@ -55,6 +55,7 @@ const SKIP_MOUNT_PREFIXES: &[&str] = &["/proc", "/sys", "/dev", "/tmp"];
 /// Default directories that are allowed to be writable.
 /// These are common application config/cache directories that many programs need.
 const DEFAULT_ALLOWED_DIRS: &[&str] = &[
+    ".amp",         // Amp config
     ".claude",      // Claude Code config
     ".claude.json", // Claude Code config file
     ".codex",       // OpenAI Codex config


### PR DESCRIPTION
Add `.gemini`, `.amp` to allow list to make it editable. Without this, gemini fails with 

<img width="2728" height="1844" alt="gemini" src="https://github.com/user-attachments/assets/d02b409b-d582-49e6-9130-bd4eccde68f7" />

and amp fails with 

<img width="1350" height="278" alt="CleanShot 2026-01-09 at 19 50 26@2x" src="https://github.com/user-attachments/assets/cda6e6b5-04f4-4b28-a062-6d93a3351c5a" />

Workaround without this fix

`agentfs --allow ~/.gemini --session fix-gemini run bash`

Both these agents need to write to their respective dot folders in home dir. I am not sure what's the plan for supporting several agents with AgentFS but wanted to raise this PR already to start a discussion. 

P.S. vim also needs this in the allowlist but I won't add that before confirming with the maintainers. 

<img width="1458" height="356" alt="CleanShot 2026-01-09 at 18 51 45@2x" src="https://github.com/user-attachments/assets/083fe897-daca-455f-b0a4-02c27c2f6fc1" />
