### PR TITLE
sdk/rust: Return ENOENT instead of EIO for file not found errors

### DIFF
--- a/sdk/rust/src/filesystem/hostfs.rs
+++ b/sdk/rust/src/filesystem/hostfs.rs
@@ -8,7 +8,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 #[cfg(unix)]
 use libc;
 
-use super::{BoxedFile, DirEntry, File, FileSystem, FilesystemStats, Stats};
+use super::{BoxedFile, DirEntry, File, FileSystem, FilesystemStats, FsError, Stats};
 use std::sync::Arc;
 
 /// A filesystem backed by a host directory (passthrough)
@@ -352,7 +352,7 @@ impl FileSystem for HostFS {
         let full_path = self.resolve_path(path);
         // Verify the file exists
         if !full_path.exists() {
-            anyhow::bail!("File not found: {}", path);
+            return Err(FsError::NotFound.into());
         }
         Ok(Arc::new(HostFSFile {
             full_path,

--- a/sdk/rust/src/filesystem/overlayfs.rs
+++ b/sdk/rust/src/filesystem/overlayfs.rs
@@ -363,7 +363,7 @@ impl File for OverlayFile {
         if let Some(ref file) = self.base_file {
             return file.fstat().await;
         }
-        anyhow::bail!("File not found")
+        Err(FsError::NotFound.into())
     }
 }
 
@@ -1196,7 +1196,7 @@ impl FileSystem for OverlayFS {
 
         // Check for whiteout
         if self.is_whiteout(&normalized) {
-            anyhow::bail!("File not found (whiteout): {}", path);
+            return Err(FsError::NotFound.into());
         }
 
         // Try to open from delta
@@ -1211,7 +1211,7 @@ impl FileSystem for OverlayFS {
 
         // Must exist in at least one layer
         if delta_file.is_none() && base_file.is_none() {
-            anyhow::bail!("File not found: {}", path);
+            return Err(FsError::NotFound.into());
         }
 
         Ok(Arc::new(OverlayFile {


### PR DESCRIPTION
Replace anyhow::bail! and anyhow::anyhow! with FsError::NotFound for "file not found" errors. This ensures the FUSE layer returns ENOENT instead of EIO, which is the correct errno for missing files.

Previously, the FUSE error_to_errno() function would fall back to EIO for any error that couldn't be downcast to FsError, causing confusing "I/O error" messages when files simply didn't exist.