### PR TITLE
cli: Add `agentfs prune mounts` command

### DIFF
--- a/cli/src/cmd/mount_stub.rs
+++ b/cli/src/cmd/mount_stub.rs
@@ -30,3 +30,8 @@ pub fn list_mounts<W: Write>(out: &mut W) {
 pub fn mount(_args: MountArgs) -> Result<()> {
     anyhow::bail!("FUSE mount is only available on Linux")
 }
+
+/// Prune unused agentfs mount points.
+pub fn prune_mounts(_force: bool) -> Result<()> {
+    anyhow::bail!("Mount pruning is only available on Linux")
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use agentfs::{
     cmd::{self, completions::handle_completions},
     get_runtime,
-    parser::{Args, Command, FsCommand, ServeCommand, SyncCommand},
+    parser::{Args, Command, FsCommand, PruneCommand, ServeCommand, SyncCommand},
 };
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -246,6 +246,14 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Command::Prune { command } => match command {
+            PruneCommand::Mounts { force } => {
+                if let Err(e) = cmd::mount::prune_mounts(force) {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        },
     }
 }
 

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -202,6 +202,11 @@ pub enum Command {
     },
     /// List active agentfs run sessions
     Ps,
+    /// Prune unused resources
+    Prune {
+        #[command(subcommand)]
+        command: PruneCommand,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -268,6 +273,16 @@ pub enum ServeCommand {
         /// copy_file, rename, stat, access, kv_get, kv_set, kv_delete, kv_list
         #[arg(long, value_delimiter = ',')]
         tools: Option<Vec<String>>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PruneCommand {
+    /// Unmount unused agentfs mount points
+    Mounts {
+        /// Skip confirmation prompt and unmount immediately
+        #[arg(long)]
+        force: bool,
     },
 }
 


### PR DESCRIPTION
Add a new command to unmount unused agentfs mount points. The command scans /proc to detect which mounts have no processes with open files or current working directory on them, then unmounts those.