### PR TITLE
agentfs run: Group paths by parent directory in welcome banner

### DIFF
--- a/cli/src/cmd/run_darwin.rs
+++ b/cli/src/cmd/run_darwin.rs
@@ -124,14 +124,16 @@ pub async fn run(
 /// Print the welcome banner showing sandbox configuration (macOS).
 #[cfg(target_os = "macos")]
 fn print_welcome_banner(session: &RunSession) {
+    use crate::sandbox::group_paths_by_parent;
+
     eprintln!("Welcome to AgentFS!");
     eprintln!();
     eprintln!("The following directories are writable:");
     eprintln!();
     eprintln!("  - {} (copy-on-write)", session.cwd.display());
     eprintln!("  - /tmp");
-    for path in &session.allow_paths {
-        eprintln!("  - {}", path.display());
+    for grouped_path in group_paths_by_parent(&session.allow_paths) {
+        eprintln!("  - {}", grouped_path);
     }
     eprintln!();
     eprintln!("🔒 Everything else is read-only.");

--- a/cli/src/sandbox/linux.rs
+++ b/cli/src/sandbox/linux.rs
@@ -15,6 +15,7 @@
 //! The HostFS base layer then accesses files through `/proc/self/fd/N`,
 //! bypassing the FUSE mount entirely.
 
+use super::group_paths_by_parent;
 use agentfs_sdk::{AgentFS, AgentFSOptions, FileSystem, HostFS, OverlayFS};
 use anyhow::{bail, Context, Result};
 use std::{
@@ -406,8 +407,8 @@ fn print_welcome_banner(cwd: &Path, allowed_paths: &[PathBuf], session_id: &str)
     eprintln!("The following directories are writable:");
     eprintln!();
     eprintln!("  - {} (copy-on-write)", cwd.display());
-    for path in allowed_paths {
-        eprintln!("  - {}", path.display());
+    for grouped_path in group_paths_by_parent(allowed_paths) {
+        eprintln!("  - {}", grouped_path);
     }
     eprintln!();
     eprintln!("🔒 Everything else is read-only.");

--- a/cli/src/sandbox/mod.rs
+++ b/cli/src/sandbox/mod.rs
@@ -5,6 +5,9 @@
 //! - `linux_ptrace`: ptrace-based syscall interception sandbox (experimental)
 //! - `darwin`: Kernel-enforced sandbox using sandbox-exec
 
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
 #[cfg(all(target_os = "linux", feature = "sandbox"))]
 pub mod linux;
 
@@ -13,3 +16,43 @@ pub mod linux_ptrace;
 
 #[cfg(all(target_os = "macos", feature = "sandbox"))]
 pub mod darwin;
+
+/// Group paths by parent directory and format using brace expansion.
+///
+/// For example, given paths:
+/// - /home/user/.claude
+/// - /home/user/.claude.json
+/// - /home/user/.codex
+/// - /home/user/.npm
+///
+/// Returns: `["/home/user/{.claude, .claude.json, .codex, .npm}"]`
+pub fn group_paths_by_parent(paths: &[PathBuf]) -> Vec<String> {
+    let mut groups: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
+
+    for path in paths {
+        let (parent, name) = match (path.parent(), path.file_name()) {
+            (Some(parent), Some(name)) => {
+                (parent.to_path_buf(), name.to_string_lossy().to_string())
+            }
+            _ => (PathBuf::new(), path.display().to_string()),
+        };
+        groups.entry(parent).or_default().push(name);
+    }
+
+    groups
+        .into_iter()
+        .map(|(parent, mut names)| {
+            names.sort();
+            let parent_str = parent.display().to_string();
+            if names.len() == 1 {
+                if parent_str.is_empty() {
+                    names.remove(0)
+                } else {
+                    format!("{}/{}", parent_str, names[0])
+                }
+            } else {
+                format!("{}/{{{}}}", parent_str, names.join(", "))
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
Use brace expansion syntax to group paths with the same parent directory, making the output more readable when multiple config files are in $HOME.