### PR TITLE
Optimize FUSE create() to use single create_file operation

### DIFF
--- a/sdk/rust/src/filesystem/hostfs.rs
+++ b/sdk/rust/src/filesystem/hostfs.rs
@@ -359,6 +359,15 @@ impl FileSystem for HostFS {
             virtual_path: path.to_string(),
         }))
     }
+
+    async fn create_file(&self, path: &str, mode: u32) -> Result<(Stats, BoxedFile)> {
+        // Fallback implementation for HostFS
+        self.write_file(path, &[]).await?;
+        self.chmod(path, mode).await?;
+        let stats = self.stat(path).await?.ok_or(FsError::NotFound)?;
+        let file = self.open(path).await?;
+        Ok((stats, file))
+    }
 }
 
 #[cfg(test)]

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -216,4 +216,11 @@ pub trait FileSystem: Send + Sync {
     /// The returned file handle can be used for efficient read/write/fsync
     /// operations without requiring path lookups on each operation.
     async fn open(&self, path: &str) -> Result<BoxedFile>;
+
+    /// Create a new empty file with the specified mode.
+    ///
+    /// Returns both the file stats and an open file handle in a single operation.
+    /// This is optimized for FUSE create() which needs both atomically.
+    /// Fails with AlreadyExists if the file exists.
+    async fn create_file(&self, path: &str, mode: u32) -> Result<(Stats, BoxedFile)>;
 }


### PR DESCRIPTION
Eliminates redundant operations in file creation path:
- Before: write_file + chmod + stat + open (4 path resolutions, ~7 SQLite ops)
- After: create_file (1 path resolution, 2 SQLite ops)

Adds create_file method to FileSystem trait that atomically creates an empty file with the requested mode and returns both Stats and an open file handle, avoiding separate chmod/stat/open calls.

Before:

> agentfs run npx create-react-app my-app

real    0m37.476s
user    0m36.813s
sys     0m12.236s

After:

> agentfs run npx create-react-app my-app

real    0m30.314s
user    0m31.048s
sys     0m10.988s