### PR TITLE
sdk/rust: Replace anyhow with custom Error type

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -121,7 +121,6 @@ name = "agentfs-sdk"
 version = "0.5.3"
 dependencies = [
  "aegis",
- "anyhow",
  "async-trait",
  "libc",
  "lru",

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -52,7 +52,6 @@ name = "agentfs-sdk"
 version = "0.5.3"
 dependencies = [
  "aegis",
- "anyhow",
  "async-trait",
  "criterion",
  "libc",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -12,7 +12,6 @@ async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 libc = "0.2"
-anyhow = "1.0"
 thiserror = "1.0"
 lru = "0.12"
 

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -1,0 +1,58 @@
+//! Error types for the AgentFS SDK.
+
+use thiserror::Error;
+
+/// The main error type for the AgentFS SDK.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Database error from turso
+    #[error("database error: {0}")]
+    Database(#[from] turso::Error),
+
+    /// IO error
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization/deserialization error
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// System time error
+    #[error("time error: {0}")]
+    Time(#[from] std::time::SystemTimeError),
+
+    /// Filesystem-specific error with errno semantics
+    #[error(transparent)]
+    Fs(#[from] crate::filesystem::FsError),
+
+    /// Invalid agent ID format
+    #[error("invalid agent ID '{0}': agent IDs must contain only alphanumeric characters, hyphens, and underscores")]
+    InvalidAgentId(String),
+
+    /// Agent not found
+    #[error("agent '{id}' not found at '{path}'")]
+    AgentNotFound { id: String, path: String },
+
+    /// Invalid path encoding
+    #[error("path '{0}' is not valid UTF-8")]
+    InvalidUtf8Path(String),
+
+    /// Base directory does not exist
+    #[error("base directory does not exist: {0}")]
+    BaseDirectoryNotFound(String),
+
+    /// Path is not a directory
+    #[error("path is not a directory: {0}")]
+    NotADirectory(String),
+
+    /// Tool call not found
+    #[error("tool call not found")]
+    ToolCallNotFound,
+
+    /// Internal error (for unexpected conditions)
+    #[error("{0}")]
+    Internal(String),
+}
+
+/// Result type alias using the SDK Error type.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/sdk/rust/src/filesystem/hostfs.rs
+++ b/sdk/rust/src/filesystem/hostfs.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::error::{Error, Result};
 use async_trait::async_trait;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
@@ -95,10 +95,10 @@ impl HostFS {
     pub fn new(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         if !root.exists() {
-            anyhow::bail!("Root directory does not exist: {}", root.display());
+            return Err(Error::BaseDirectoryNotFound(root.display().to_string()));
         }
         if !root.is_dir() {
-            anyhow::bail!("Root path is not a directory: {}", root.display());
+            return Err(Error::NotADirectory(root.display().to_string()));
         }
         Ok(Self {
             root,

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -3,7 +3,7 @@ pub mod agentfs;
 pub mod hostfs;
 pub mod overlayfs;
 
-use anyhow::Result;
+use crate::error::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 use thiserror::Error;

--- a/sdk/rust/src/filesystem/overlayfs.rs
+++ b/sdk/rust/src/filesystem/overlayfs.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::error::Result;
 use async_trait::async_trait;
 use std::{
     collections::{HashMap, HashSet},
@@ -1172,7 +1172,7 @@ impl FileSystem for OverlayFS {
             if let Some(stats) = base_stats {
                 // Hard links to directories are not allowed
                 if stats.is_directory() {
-                    anyhow::bail!("Cannot create hard link to directory");
+                    return Err(FsError::IsADirectory.into());
                 }
                 // Copy-up: read from base and write to delta
                 if let Some(data) = self.base.read_file(&old_normalized).await? {

--- a/sdk/rust/src/kvstore.rs
+++ b/sdk/rust/src/kvstore.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::error::Result;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use turso::{Builder, Connection};

--- a/sdk/rust/src/toolcalls.rs
+++ b/sdk/rust/src/toolcalls.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,
@@ -149,7 +149,7 @@ impl ToolCalls {
             .get_value(0)
             .ok()
             .and_then(|v| v.as_integer().copied())
-            .ok_or_else(|| anyhow::anyhow!("Failed to get tool call ID"))?;
+            .ok_or_else(|| Error::Internal("failed to get tool call ID".to_string()))?;
         Ok(id)
     }
 
@@ -168,9 +168,9 @@ impl ToolCalls {
             row.get_value(0)
                 .ok()
                 .and_then(|v| v.as_integer().copied())
-                .ok_or_else(|| anyhow::anyhow!("Invalid started_at value"))?
+                .ok_or_else(|| Error::Internal("invalid started_at value".to_string()))?
         } else {
-            anyhow::bail!("Tool call not found");
+            return Err(Error::ToolCallNotFound);
         };
 
         let duration_ms = (completed_at - started_at) * 1000;
@@ -232,7 +232,7 @@ impl ToolCalls {
             .get_value(0)
             .ok()
             .and_then(|v| v.as_integer().copied())
-            .ok_or_else(|| anyhow::anyhow!("Failed to get tool call ID"))?;
+            .ok_or_else(|| Error::Internal("failed to get tool call ID".to_string()))?;
         Ok(id)
     }
 
@@ -250,9 +250,9 @@ impl ToolCalls {
             row.get_value(0)
                 .ok()
                 .and_then(|v| v.as_integer().copied())
-                .ok_or_else(|| anyhow::anyhow!("Invalid started_at value"))?
+                .ok_or_else(|| Error::Internal("invalid started_at value".to_string()))?
         } else {
-            anyhow::bail!("Tool call not found");
+            return Err(Error::ToolCallNotFound);
         };
 
         let duration_ms = (completed_at - started_at) * 1000;


### PR DESCRIPTION
Remove direct dependency on anyhow crate by introducing a custom Error type using thiserror. This provides more specific error variants for better error handling and removes unnecessary abstraction.