### PR TITLE
sdk/rust: Move sync logic from CLI to SDK

### DIFF
--- a/cli/src/cmd/fs.rs
+++ b/cli/src/cmd/fs.rs
@@ -20,7 +20,7 @@ pub async fn ls_filesystem(
     let options = AgentFSOptions::resolve(&id_or_path)?;
     eprintln!("Using agent: {}", id_or_path);
 
-    let (_, agentfs) = open_agentfs(options).await?;
+    let agentfs = open_agentfs(options).await?;
     let conn = agentfs.get_connection();
 
     if path != "/" {
@@ -101,7 +101,7 @@ pub async fn cat_filesystem(
     path: &str,
 ) -> AnyhowResult<()> {
     let options = AgentFSOptions::resolve(&id_or_path)?;
-    let (_, agentfs) = open_agentfs(options).await?;
+    let agentfs = open_agentfs(options).await?;
 
     match agentfs.fs.read_file(path).await? {
         Some(file) => {
@@ -114,7 +114,7 @@ pub async fn cat_filesystem(
 
 pub async fn write_filesystem(id_or_path: String, path: &str, content: &str) -> AnyhowResult<()> {
     let options = AgentFSOptions::resolve(&id_or_path)?;
-    let (_, agentfs) = open_agentfs(options).await?;
+    let agentfs = open_agentfs(options).await?;
 
     let mut components = path.split("/").collect::<Vec<_>>();
     if !path.starts_with("/") {
@@ -170,9 +170,7 @@ pub async fn diff_filesystem(id_or_path: String) -> AnyhowResult<()> {
     let options = AgentFSOptions::resolve(&id_or_path)?;
     eprintln!("Using agent: {}", id_or_path);
 
-    let (_, agent) = open_agentfs(options)
-        .await
-        .context("Failed to open agent")?;
+    let agent = open_agentfs(options).await?;
 
     // Check if overlay is enabled
     let base_path = match agent.is_overlay_enabled().await? {

--- a/cli/src/cmd/init.rs
+++ b/cli/src/cmd/init.rs
@@ -1,86 +1,67 @@
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use agentfs_sdk::{agentfs_dir, AgentFS, AgentFSOptions, OverlayFS};
+use agentfs_sdk::{
+    agentfs_dir, AgentFS, AgentFSOptions, OverlayFS, PartialBootstrapStrategy, PartialSyncOpts,
+    SyncOptions,
+};
 use anyhow::{Context, Result as AnyhowResult};
-use turso::sync::{PartialBootstrapStrategy, PartialSyncOpts};
 
 use crate::parser::SyncCommandOptions;
 
-pub async fn open_agentfs(
-    options: AgentFSOptions,
-) -> anyhow::Result<(Option<turso::sync::Database>, AgentFS)> {
-    let path = options.db_path()?;
-    let meta_path = format!("{path}-info");
-    if !std::fs::exists(meta_path)? {
-        return Ok((
-            None,
-            AgentFS::open(options)
-                .await
-                .context("Failed to open database")?,
-        ));
+pub async fn open_agentfs(options: AgentFSOptions) -> anyhow::Result<AgentFS> {
+    let mut options = options;
+    // CLI handles env var fallback for auth token
+    if options.sync.auth_token.is_none() {
+        if let Ok(auth_token) = std::env::var("TURSO_DB_AUTH_TOKEN") {
+            options.sync.auth_token = Some(auth_token);
+        }
     }
-    let mut builder = turso::sync::Builder::new_remote(&options.db_path()?);
-    if let Ok(auth_token) = std::env::var("TURSO_DB_AUTH_TOKEN") {
-        builder = builder.with_auth_token(auth_token);
-    }
-    let db = builder.build().await?;
-    let conn = db.connect().await?;
-    let agent = AgentFS::open_with(conn)
+    AgentFS::open(options)
         .await
-        .context("Failed to open synced database")?;
-    Ok((Some(db), agent))
+        .context("Failed to open database")
 }
 
-pub async fn create_agentfs(
-    options: AgentFSOptions,
-    sync_options: SyncCommandOptions,
-) -> anyhow::Result<(Option<turso::sync::Database>, AgentFS)> {
-    if let Some(remote_url) = sync_options.sync_remote_url {
-        let mut builder =
-            turso::sync::Builder::new_remote(&options.db_path()?).with_remote_url(remote_url);
-        if let Ok(auth_token) = std::env::var("TURSO_DB_AUTH_TOKEN") {
-            builder = builder.with_auth_token(auth_token);
-        }
+pub fn build_sync_options(sync_cmd_options: &SyncCommandOptions) -> SyncOptions {
+    let mut sync = SyncOptions {
+        remote_url: sync_cmd_options.sync_remote_url.clone(),
+        auth_token: std::env::var("TURSO_DB_AUTH_TOKEN").ok(),
+        partial_sync: None,
+    };
+
+    if sync_cmd_options.sync_remote_url.is_some() {
         let mut partial_sync = PartialSyncOpts {
             bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 }),
             prefetch: false,
             segment_size: 128 * 1024,
         };
         let mut has_partial_sync = false;
-        if let Some(prefetch) = sync_options.sync_partial_prefetch {
+
+        if let Some(prefetch) = sync_cmd_options.sync_partial_prefetch {
             partial_sync.prefetch = prefetch;
             has_partial_sync = true;
         }
-        if let Some(segment_size) = sync_options.sync_partial_segment_size {
+        if let Some(segment_size) = sync_cmd_options.sync_partial_segment_size {
             partial_sync.segment_size = segment_size;
             has_partial_sync = true;
         }
-        if let Some(length) = sync_options.sync_partial_bootstrap_length {
+        if let Some(length) = sync_cmd_options.sync_partial_bootstrap_length {
             partial_sync.bootstrap_strategy = Some(PartialBootstrapStrategy::Prefix { length });
             has_partial_sync = true;
         }
-        if let Some(query) = sync_options.sync_partial_bootstrap_query {
-            partial_sync.bootstrap_strategy = Some(PartialBootstrapStrategy::Query { query });
+        if let Some(ref query) = sync_cmd_options.sync_partial_bootstrap_query {
+            partial_sync.bootstrap_strategy = Some(PartialBootstrapStrategy::Query {
+                query: query.clone(),
+            });
             has_partial_sync = true;
         }
+
         if has_partial_sync {
-            builder = builder.with_partial_sync_opts_experimental(partial_sync);
+            sync.partial_sync = Some(partial_sync);
         }
-        let db = builder.build().await?;
-        let conn = db.connect().await?;
-        let agent = AgentFS::open_with(conn)
-            .await
-            .context("Failed to initialize synced database")?;
-        Ok((Some(db), agent))
-    } else {
-        Ok((
-            None,
-            AgentFS::open(options)
-                .await
-                .context("Failed to initialize database")?,
-        ))
     }
+
+    sync
 }
 
 pub async fn init_database(
@@ -137,14 +118,17 @@ pub async fn init_database(
         }
     }
 
-    let mut open_options = AgentFSOptions::with_id(&id);
+    let mut open_options =
+        AgentFSOptions::with_id(&id).with_sync(build_sync_options(&sync_options));
     if let Some(base_path) = base.as_ref() {
         open_options = open_options.with_base(base_path);
     }
 
     // Use the SDK to initialize the database - this ensures consistency
     // The SDK will create .agentfs directory and database file
-    let (synced_db, agent) = create_agentfs(open_options, sync_options).await?;
+    let agent = AgentFS::open(open_options)
+        .await
+        .context("Failed to initialize database")?;
 
     // If base is provided, initialize the overlay schema using the SDK
     if let Some(base_path) = base {
@@ -159,16 +143,16 @@ pub async fn init_database(
             .await
             .context("Failed to initialize overlay schema")?;
 
-        if let Some(synced_db) = synced_db {
-            synced_db.push().await?;
+        if agent.is_synced() {
+            agent.push().await?;
         }
 
         eprintln!("Created overlay filesystem: {}", db_path.display());
         eprintln!("Agent ID: {}", id);
         eprintln!("Base: {}", base_path.display());
     } else {
-        if let Some(synced_db) = synced_db {
-            synced_db.push().await?;
+        if agent.is_synced() {
+            agent.push().await?;
         }
 
         eprintln!("Created agent filesystem: {}", db_path.display());

--- a/cli/src/cmd/mcp_server.rs
+++ b/cli/src/cmd/mcp_server.rs
@@ -23,9 +23,7 @@ pub async fn handle_mcp_server_command(
 
     eprintln!("Using agent: {}", id_or_path);
 
-    let (_, agentfs) = open_agentfs(options)
-        .await
-        .context("Failed to open AgentFS")?;
+    let agentfs = open_agentfs(options).await?;
 
     // Create MCP server with tool filtering
     let server = McpServer::new(agentfs, tools_filter);

--- a/cli/src/cmd/mount.rs
+++ b/cli/src/cmd/mount.rs
@@ -87,7 +87,7 @@ pub fn mount(args: MountArgs) -> Result<()> {
 
     let mount = move || {
         let rt = crate::get_runtime();
-        let (_db, agentfs) = rt.block_on(open_agentfs(opts))?;
+        let agentfs = rt.block_on(open_agentfs(opts))?;
 
         // Check for overlay configuration
         let fs: Arc<dyn FileSystem> = rt.block_on(async {

--- a/cli/src/cmd/nfs.rs
+++ b/cli/src/cmd/nfs.rs
@@ -26,7 +26,7 @@ pub async fn handle_nfs_command(id_or_path: String, bind: String, port: u32) -> 
         .context("Database path contains non-UTF8 characters")?;
 
     let options = AgentFSOptions::with_path(db_path_str);
-    let (_, agentfs) = open_agentfs(options).await?;
+    let agentfs = open_agentfs(options).await?;
 
     // Check if overlay is configured in the database
     let base_path = agentfs

--- a/cli/src/cmd/sync.rs
+++ b/cli/src/cmd/sync.rs
@@ -1,5 +1,4 @@
 use agentfs_sdk::AgentFSOptions;
-use anyhow::anyhow;
 
 use crate::cmd::init::open_agentfs;
 
@@ -7,11 +6,8 @@ pub async fn handle_pull_command(id_or_path: String) -> anyhow::Result<()> {
     let options = AgentFSOptions::resolve(&id_or_path)?;
     eprintln!("Using agent: {}", id_or_path);
 
-    let (db, _) = open_agentfs(options).await?;
-    let Some(db) = db else {
-        return Err(anyhow!("db is not connected to the remote"));
-    };
-    db.pull().await?;
+    let agent = open_agentfs(options).await?;
+    agent.pull().await?;
     eprintln!("Remote data pulled to local db successfully");
     Ok(())
 }
@@ -20,11 +16,8 @@ pub async fn handle_push_command(id_or_path: String) -> anyhow::Result<()> {
     let options = AgentFSOptions::resolve(&id_or_path)?;
     eprintln!("Using agent: {}", id_or_path);
 
-    let (db, _) = open_agentfs(options).await?;
-    let Some(db) = db else {
-        return Err(anyhow!("db is not connected to the remote"));
-    };
-    db.push().await?;
+    let agent = open_agentfs(options).await?;
+    agent.push().await?;
     eprintln!("Local data pushed to remote db successfully");
     Ok(())
 }
@@ -33,12 +26,9 @@ pub async fn handle_checkpoint_command(id_or_path: String) -> anyhow::Result<()>
     let options = AgentFSOptions::resolve(&id_or_path)?;
     eprintln!("Using agent: {}", id_or_path);
 
-    let (db, _) = open_agentfs(options).await?;
-    let Some(db) = db else {
-        return Err(anyhow!("db is not connected to the remote"));
-    };
-    db.checkpoint().await?;
-    eprintln!("Local db checkpoined successfully");
+    let agent = open_agentfs(options).await?;
+    agent.checkpoint().await?;
+    eprintln!("Local db checkpointed successfully");
     Ok(())
 }
 
@@ -49,11 +39,8 @@ pub async fn handle_stats_command(
     let options = AgentFSOptions::resolve(&id_or_path)?;
     eprintln!("Using agent: {}", id_or_path);
 
-    let (db, _) = open_agentfs(options).await?;
-    let Some(db) = db else {
-        return Err(anyhow!("db is not connected to the remote"));
-    };
-    let stats = db.stats().await?;
+    let agent = open_agentfs(options).await?;
+    let stats = agent.sync_stats().await?;
     stdout.write_all(serde_json::to_string(&stats)?.as_bytes())?;
     Ok(())
 }

--- a/cli/src/cmd/timeline.rs
+++ b/cli/src/cmd/timeline.rs
@@ -42,7 +42,7 @@ pub async fn show_timeline(
 ) -> AnyhowResult<()> {
     let agent_options = AgentFSOptions::resolve(id_or_path)?;
 
-    let (_, agentfs) = open_agentfs(agent_options).await?;
+    let agentfs = open_agentfs(agent_options).await?;
     let conn = agentfs.get_connection();
 
     let toolcalls = ToolCalls::from_connection(conn)

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -49,6 +49,10 @@ pub enum Error {
     #[error("tool call not found")]
     ToolCallNotFound,
 
+    /// Sync not enabled for this database
+    #[error("sync is not enabled for this database")]
+    SyncNotEnabled,
+
     /// Internal error (for unexpected conditions)
     #[error("{0}")]
     Internal(String),


### PR DESCRIPTION
Encapsulate sync database handling inside AgentFS. Cleans up code but also makes switching to connection pool model easier.