### PR TITLE
sdk/rust: Connection pooling

### DIFF
--- a/cli/src/cmd/fs.rs
+++ b/cli/src/cmd/fs.rs
@@ -21,7 +21,7 @@ pub async fn ls_filesystem(
     eprintln!("Using agent: {}", id_or_path);
 
     let agentfs = open_agentfs(options).await?;
-    let conn = agentfs.get_connection();
+    let conn = agentfs.get_connection().await?;
 
     if path != "/" {
         anyhow::bail!("Only root directory (/) is currently supported");

--- a/cli/src/cmd/init.rs
+++ b/cli/src/cmd/init.rs
@@ -139,7 +139,8 @@ pub async fn init_database(
             .to_string();
 
         // Use SDK's OverlayFS::init_schema to ensure schema consistency
-        OverlayFS::init_schema(&agent.get_connection(), &base_path_str)
+        let conn = agent.get_connection().await?;
+        OverlayFS::init_schema(&conn, &base_path_str)
             .await
             .context("Failed to initialize overlay schema")?;
 

--- a/cli/src/cmd/mount.rs
+++ b/cli/src/cmd/mount.rs
@@ -91,7 +91,7 @@ pub fn mount(args: MountArgs) -> Result<()> {
 
         // Check for overlay configuration
         let fs: Arc<dyn FileSystem> = rt.block_on(async {
-            let conn = agentfs.get_connection();
+            let conn = agentfs.get_connection().await?;
 
             // Check if fs_overlay_config table exists and has base_path
             let query = "SELECT value FROM fs_overlay_config WHERE key = 'base_path'";

--- a/cli/src/cmd/timeline.rs
+++ b/cli/src/cmd/timeline.rs
@@ -43,9 +43,8 @@ pub async fn show_timeline(
     let agent_options = AgentFSOptions::resolve(id_or_path)?;
 
     let agentfs = open_agentfs(agent_options).await?;
-    let conn = agentfs.get_connection();
 
-    let toolcalls = ToolCalls::from_connection(conn)
+    let toolcalls = ToolCalls::from_pool(agentfs.get_pool())
         .await
         .context("Failed to create tool calls tracker")?;
 

--- a/sdk/rust/src/connection_pool.rs
+++ b/sdk/rust/src/connection_pool.rs
@@ -1,0 +1,254 @@
+//! Connection pool for Turso database connections.
+//!
+//! This module provides a thread-safe connection pool that manages database
+//! connections with a maximum limit. When the pool is exhausted, callers block
+//! until a connection becomes available or timeout occurs.
+
+use std::{sync::Arc, time::Duration};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use turso::{Connection, Database};
+
+use crate::error::{Error, Result};
+
+/// Maximum number of connections in the pool.
+const MAX_CONNECTIONS: usize = 1;
+
+/// Default timeout for acquiring a connection from the pool.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Database wrapper that supports both regular and sync databases.
+enum DatabaseType {
+    Local(Database),
+    Sync(turso::sync::Database),
+}
+
+/// A pool of database connections with a maximum limit.
+///
+/// The pool enforces a maximum number of concurrent connections. When all
+/// connections are in use, `get_connection()` blocks until one becomes
+/// available or the timeout expires (returning `ConnectionPoolTimeout`).
+#[derive(Clone)]
+pub struct ConnectionPool {
+    inner: Arc<ConnectionPoolInner>,
+}
+
+struct ConnectionPoolInner {
+    db: DatabaseType,
+    /// Available connections ready to be reused
+    pool: Mutex<Vec<Connection>>,
+    /// Semaphore to limit concurrent connections
+    semaphore: Arc<Semaphore>,
+    /// Timeout for acquiring a connection
+    timeout: Duration,
+}
+
+impl ConnectionPool {
+    /// Create a new connection pool from a database.
+    pub fn new(db: Database) -> Self {
+        Self::with_timeout(DatabaseType::Local(db), DEFAULT_TIMEOUT)
+    }
+
+    /// Create a new connection pool from a sync database.
+    pub fn new_sync(db: turso::sync::Database) -> Self {
+        Self::with_timeout(DatabaseType::Sync(db), DEFAULT_TIMEOUT)
+    }
+
+    /// Create a connection pool with a custom timeout.
+    fn with_timeout(db: DatabaseType, timeout: Duration) -> Self {
+        Self {
+            inner: Arc::new(ConnectionPoolInner {
+                db,
+                pool: Mutex::new(Vec::new()),
+                semaphore: Arc::new(Semaphore::new(MAX_CONNECTIONS)),
+                timeout,
+            }),
+        }
+    }
+
+    /// Get a connection from the pool.
+    ///
+    /// If a pooled connection is available, it is returned immediately.
+    /// Otherwise, if the pool hasn't reached max capacity, a new connection
+    /// is created. If at max capacity, this blocks until a connection is
+    /// returned to the pool or timeout expires.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::ConnectionPoolTimeout` if no connection becomes
+    /// available within the timeout period.
+    pub async fn get_connection(&self) -> Result<PooledConnection> {
+        // Try to acquire a permit with timeout
+        let permit = tokio::time::timeout(
+            self.inner.timeout,
+            Arc::clone(&self.inner.semaphore).acquire_owned(),
+        )
+        .await
+        .map_err(|_| Error::ConnectionPoolTimeout)?
+        .map_err(|_| Error::Internal("semaphore closed".to_string()))?;
+
+        // We have a permit - try to get an existing connection or create new one
+        let conn = {
+            let mut pool = self.inner.pool.lock().await;
+            pool.pop()
+        };
+
+        let conn = match conn {
+            Some(c) => c,
+            None => match &self.inner.db {
+                DatabaseType::Local(db) => db.connect()?,
+                DatabaseType::Sync(db) => db.connect().await?,
+            },
+        };
+
+        Ok(PooledConnection {
+            conn: Some(conn),
+            pool: self.inner.clone(),
+            _permit: permit,
+        })
+    }
+
+    /// Get the underlying database reference (for creating additional connections).
+    /// Returns None if this is a sync database.
+    pub fn database(&self) -> Option<&Database> {
+        match &self.inner.db {
+            DatabaseType::Local(db) => Some(db),
+            DatabaseType::Sync(_) => None,
+        }
+    }
+
+    /// Get the underlying sync database reference.
+    pub fn sync_database(&self) -> Option<&turso::sync::Database> {
+        match &self.inner.db {
+            DatabaseType::Local(_) => None,
+            DatabaseType::Sync(db) => Some(db),
+        }
+    }
+}
+
+/// A connection borrowed from the pool.
+///
+/// When dropped, the connection is returned to the pool for reuse and the
+/// semaphore permit is released, allowing another caller to acquire a connection.
+pub struct PooledConnection {
+    conn: Option<Connection>,
+    pool: Arc<ConnectionPoolInner>,
+    /// Held permit - released when this is dropped
+    _permit: OwnedSemaphorePermit,
+}
+
+impl PooledConnection {
+    /// Get a reference to the underlying connection.
+    pub fn connection(&self) -> &Connection {
+        self.conn.as_ref().expect("connection already taken")
+    }
+}
+
+impl std::ops::Deref for PooledConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        self.connection()
+    }
+}
+
+impl Drop for PooledConnection {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            // Return connection to pool - use try_lock to avoid blocking in drop
+            // If we can't get the lock, just drop the connection (it will be recreated)
+            if let Ok(mut pool) = self.pool.pool.try_lock() {
+                pool.push(conn);
+            }
+            // Permit is automatically released when _permit is dropped
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use turso::Builder;
+
+    #[tokio::test]
+    async fn test_connection_pool_basic() {
+        let db = Builder::new_local(":memory:").build().await.unwrap();
+        let pool = ConnectionPool::new(db);
+
+        // Get a connection
+        let conn = pool.get_connection().await.unwrap();
+        assert!(conn.conn.is_some());
+
+        // Drop it
+        drop(conn);
+
+        // Get another - should reuse the pooled one
+        let conn2 = pool.get_connection().await.unwrap();
+        assert!(conn2.conn.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_max_one() {
+        let db = Builder::new_local(":memory:").build().await.unwrap();
+        let pool = ConnectionPool::new(db);
+
+        // Get the one allowed connection
+        let conn1 = pool.get_connection().await.unwrap();
+        assert!(conn1.conn.is_some());
+
+        // Try to get another - should timeout quickly
+        let pool_clone = pool.clone();
+        let result =
+            tokio::time::timeout(Duration::from_millis(100), pool_clone.get_connection()).await;
+
+        // Should timeout since we only have 1 connection allowed
+        assert!(result.is_err());
+
+        // Drop conn1, now we should be able to get a connection
+        drop(conn1);
+        let conn2 = pool.get_connection().await.unwrap();
+        assert!(conn2.conn.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_timeout_error() {
+        // Create pool with very short timeout
+        let db = Builder::new_local(":memory:").build().await.unwrap();
+        let pool = ConnectionPool::with_timeout(DatabaseType::Local(db), Duration::from_millis(50));
+
+        // Hold the one connection
+        let _conn1 = pool.get_connection().await.unwrap();
+
+        // Try to get another - should return ConnectionPoolTimeout
+        let result = pool.get_connection().await;
+        assert!(matches!(result, Err(Error::ConnectionPoolTimeout)));
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_concurrent_waiters() {
+        let db = Builder::new_local(":memory:").build().await.unwrap();
+        let pool = ConnectionPool::new(db);
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        // Spawn multiple tasks that all want the connection
+        let mut handles = vec![];
+        for _ in 0..5 {
+            let pool = pool.clone();
+            let counter = counter.clone();
+            handles.push(tokio::spawn(async move {
+                let _conn = pool.get_connection().await.unwrap();
+                counter.fetch_add(1, Ordering::SeqCst);
+                // Hold connection briefly
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }));
+        }
+
+        // Wait for all to complete
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // All 5 should have completed (serially, since max=1)
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+    }
+}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -53,6 +53,10 @@ pub enum Error {
     #[error("sync is not enabled for this database")]
     SyncNotEnabled,
 
+    /// Connection pool timeout - no connections available
+    #[error("connection pool timeout: no connections available")]
+    ConnectionPoolTimeout,
+
     /// Internal error (for unexpected conditions)
     #[error("{0}")]
     Internal(String),

--- a/sdk/rust/src/kvstore.rs
+++ b/sdk/rust/src/kvstore.rs
@@ -1,78 +1,75 @@
+use crate::connection_pool::ConnectionPool;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use turso::{Builder, Connection};
+use turso::Builder;
 
 /// A key-value store backed by SQLite
 #[derive(Clone)]
 pub struct KvStore {
-    conn: Arc<Connection>,
+    pool: ConnectionPool,
 }
 
 impl KvStore {
     /// Create a new KV store
     pub async fn new(db_path: &str) -> Result<Self> {
         let db = Builder::new_local(db_path).build().await?;
-        let conn = db.connect()?;
-        let kv = Self {
-            conn: Arc::new(conn),
-        };
+        let pool = ConnectionPool::new(db);
+        let kv = Self { pool };
         kv.initialize().await?;
         Ok(kv)
     }
 
-    /// Create a KV store from an existing connection
-    pub async fn from_connection(conn: Arc<Connection>) -> Result<Self> {
-        let kv = Self { conn };
+    /// Create a KV store from a connection pool
+    pub async fn from_pool(pool: ConnectionPool) -> Result<Self> {
+        let kv = Self { pool };
         kv.initialize().await?;
         Ok(kv)
     }
 
     /// Initialize the database schema
     async fn initialize(&self) -> Result<()> {
-        self.conn
-            .execute(
-                "CREATE TABLE IF NOT EXISTS kv_store (
-                    key TEXT PRIMARY KEY,
-                    value TEXT NOT NULL,
-                    created_at INTEGER DEFAULT (unixepoch()),
-                    updated_at INTEGER DEFAULT (unixepoch())
-                )",
-                (),
-            )
-            .await?;
+        let conn = self.pool.get_connection().await?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS kv_store (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                created_at INTEGER DEFAULT (unixepoch()),
+                updated_at INTEGER DEFAULT (unixepoch())
+            )",
+            (),
+        )
+        .await?;
 
-        self.conn
-            .execute(
-                "CREATE INDEX IF NOT EXISTS idx_kv_store_created_at
-                ON kv_store(created_at)",
-                (),
-            )
-            .await?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_kv_store_created_at
+            ON kv_store(created_at)",
+            (),
+        )
+        .await?;
 
         Ok(())
     }
 
     /// Set a key-value pair
     pub async fn set<V: Serialize>(&self, key: &str, value: &V) -> Result<()> {
+        let conn = self.pool.get_connection().await?;
         let serialized = serde_json::to_string(value)?;
-        self.conn
-            .execute(
-                "INSERT INTO kv_store (key, value, updated_at)
-                VALUES (?, ?, unixepoch())
-                ON CONFLICT(key) DO UPDATE SET
-                    value = excluded.value,
-                    updated_at = unixepoch()",
-                (key, serialized.as_str()),
-            )
-            .await?;
+        conn.execute(
+            "INSERT INTO kv_store (key, value, updated_at)
+            VALUES (?, ?, unixepoch())
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = unixepoch()",
+            (key, serialized.as_str()),
+        )
+        .await?;
         Ok(())
     }
 
     /// Get a value by key
     pub async fn get<V: for<'de> Deserialize<'de>>(&self, key: &str) -> Result<Option<V>> {
-        let mut rows = self
-            .conn
+        let conn = self.pool.get_connection().await?;
+        let mut rows = conn
             .query("SELECT value FROM kv_store WHERE key = ?", (key,))
             .await?;
 
@@ -96,15 +93,16 @@ impl KvStore {
 
     /// Delete a key
     pub async fn delete(&self, key: &str) -> Result<()> {
-        self.conn
-            .execute("DELETE FROM kv_store WHERE key = ?", (key,))
+        let conn = self.pool.get_connection().await?;
+        conn.execute("DELETE FROM kv_store WHERE key = ?", (key,))
             .await?;
         Ok(())
     }
 
     /// List all keys
     pub async fn keys(&self) -> Result<Vec<String>> {
-        let mut rows = self.conn.query("SELECT key FROM kv_store", ()).await?;
+        let conn = self.pool.get_connection().await?;
+        let mut rows = conn.query("SELECT key FROM kv_store", ()).await?;
         let mut keys = Vec::new();
         while let Some(row) = rows.next().await? {
             if let Some(key) = row.get_value(0).ok().and_then(|v| {


### PR DESCRIPTION
Currently, we use a single connection for all filesystem operations. In preparation for asynchronous execution, let's switch to a connection pool model.