### PR TITLE
remove FUSE_MAX_PAGES flag

### DIFF
--- a/cli/src/fuser/mod.rs
+++ b/cli/src/fuser/mod.rs
@@ -66,11 +66,7 @@ mod session;
 const INIT_FLAGS: u64 = FUSE_ASYNC_READ | FUSE_BIG_WRITES;
 
 const fn default_init_flags(#[allow(unused_variables)] capabilities: u64) -> u64 {
-    let mut flags = INIT_FLAGS;
-    if capabilities & FUSE_MAX_PAGES != 0 {
-        flags |= FUSE_MAX_PAGES;
-    }
-    flags
+    INIT_FLAGS
 }
 
 /// File types


### PR DESCRIPTION
- pub max_pages: u16 available only at abi-7-28 which we don't set right now
- so, we don't set `max_pages` and it seems like kernel fallback to default value and our setting has no effect and FUSE always receive writes no longer than 4KB


This change shows improvement for simple dd command for me locally - but not for CRA example:

```
# before
$> agentfs run dd if=/dev/zero of=kekfile bs=1M count=64
...
67108864 bytes (67 MB, 64 MiB) copied, 0.877058 s, 76.5 MB/s
...

# after
$> agentfs run dd if=/dev/zero of=kekfile bs=1M count=64
...
67108864 bytes (67 MB, 64 MiB) copied, 0.366869 s, 183 MB/s
...
```