### PR TITLE
Add POSIX file permissions support

### DIFF
--- a/cli/src/cmd/fs.rs
+++ b/cli/src/cmd/fs.rs
@@ -125,10 +125,13 @@ pub async fn write_filesystem(id_or_path: String, path: &str, content: &str) -> 
     for i in 2..components.len() {
         let dir_path = components[0..i].join("/");
         if agentfs.fs.stat(&dir_path).await?.is_none() {
-            agentfs.fs.mkdir(&dir_path).await?;
+            agentfs.fs.mkdir(&dir_path, 0, 0).await?;
         }
     }
-    agentfs.fs.write_file(path, content.as_bytes()).await?;
+    agentfs
+        .fs
+        .write_file(path, content.as_bytes(), 0, 0)
+        .await?;
     Ok(())
 }
 
@@ -268,7 +271,11 @@ mod tests {
     pub async fn cat_file_found() {
         let (agentfs, path, _file) = agentfs().await;
         let content = b"hello, agentfs";
-        agentfs.fs.write_file("test.md", content).await.unwrap();
+        agentfs
+            .fs
+            .write_file("test.md", content, 0, 0)
+            .await
+            .unwrap();
         let mut buf = Vec::new();
         cat_filesystem(&mut buf, path, "test.md").await.unwrap();
         assert_eq!(buf, content);
@@ -278,7 +285,11 @@ mod tests {
     pub async fn cat_big_file_found() {
         let (agentfs, path, _file) = agentfs().await;
         let content = vec![100u8; 4 * 1024 * 1024];
-        agentfs.fs.write_file("test.md", &content).await.unwrap();
+        agentfs
+            .fs
+            .write_file("test.md", &content, 0, 0)
+            .await
+            .unwrap();
         let mut buf = Vec::new();
         cat_filesystem(&mut buf, path, "test.md").await.unwrap();
         assert_eq!(buf, content);
@@ -295,10 +306,10 @@ mod tests {
     #[tokio::test]
     pub async fn ls_files_only() {
         let (agentfs, path, _file) = agentfs().await;
-        agentfs.fs.write_file("1.md", b"1").await.unwrap();
-        agentfs.fs.write_file("2.md", b"11").await.unwrap();
+        agentfs.fs.write_file("1.md", b"1", 0, 0).await.unwrap();
+        agentfs.fs.write_file("2.md", b"11", 0, 0).await.unwrap();
         let big = vec![100u8; 1024 * 1024];
-        agentfs.fs.write_file("3.md", &big).await.unwrap();
+        agentfs.fs.write_file("3.md", &big, 0, 0).await.unwrap();
         let mut buf = Vec::new();
         ls_filesystem(&mut buf, path, "/").await.unwrap();
         assert_eq!(
@@ -313,15 +324,19 @@ f 3.md
     #[tokio::test]
     pub async fn ls_dirs() {
         let (agentfs, path, _file) = agentfs().await;
-        agentfs.fs.mkdir("a").await.unwrap();
-        agentfs.fs.mkdir("a/b").await.unwrap();
-        agentfs.fs.mkdir("a/c").await.unwrap();
-        agentfs.fs.mkdir("d").await.unwrap();
-        agentfs.fs.mkdir("d/e").await.unwrap();
-        agentfs.fs.write_file("a/b/1.md", b"1").await.unwrap();
-        agentfs.fs.write_file("a/c/2.md", b"11").await.unwrap();
+        agentfs.fs.mkdir("a", 0, 0).await.unwrap();
+        agentfs.fs.mkdir("a/b", 0, 0).await.unwrap();
+        agentfs.fs.mkdir("a/c", 0, 0).await.unwrap();
+        agentfs.fs.mkdir("d", 0, 0).await.unwrap();
+        agentfs.fs.mkdir("d/e", 0, 0).await.unwrap();
+        agentfs.fs.write_file("a/b/1.md", b"1", 0, 0).await.unwrap();
+        agentfs
+            .fs
+            .write_file("a/c/2.md", b"11", 0, 0)
+            .await
+            .unwrap();
         let big = vec![100u8; 1024 * 1024];
-        agentfs.fs.write_file("d/e/3.md", &big).await.unwrap();
+        agentfs.fs.write_file("d/e/3.md", &big, 0, 0).await.unwrap();
         let mut buf = Vec::new();
         ls_filesystem(&mut buf, path, "/").await.unwrap();
         assert_eq!(

--- a/cli/src/cmd/mcp_server.rs
+++ b/cli/src/cmd/mcp_server.rs
@@ -675,7 +675,7 @@ impl McpServer {
 
         self.agentfs
             .fs
-            .write_file(&path, &data)
+            .write_file(&path, &data, 0, 0)
             .await
             .context("Failed to write file")?;
 
@@ -708,7 +708,7 @@ impl McpServer {
             // Create parent
             self.agentfs
                 .fs
-                .mkdir(&parent_path)
+                .mkdir(&parent_path, 0, 0)
                 .await
                 .context(format!("Failed to create directory: {}", parent_path))?;
 
@@ -737,7 +737,7 @@ impl McpServer {
 
         self.agentfs
             .fs
-            .mkdir(&path)
+            .mkdir(&path, 0, 0)
             .await
             .context("Failed to create directory")?;
 

--- a/cli/src/cmd/mount.rs
+++ b/cli/src/cmd/mount.rs
@@ -22,6 +22,8 @@ pub struct MountArgs {
     pub auto_unmount: bool,
     /// Allow root to access the mount.
     pub allow_root: bool,
+    /// Allow other system users to access the mount.
+    pub allow_other: bool,
     /// Run in foreground (don't daemonize).
     pub foreground: bool,
     /// User ID to report for all files (defaults to current user).
@@ -68,6 +70,7 @@ pub fn mount(args: MountArgs) -> Result<()> {
         mountpoint: args.mountpoint,
         auto_unmount: args.auto_unmount,
         allow_root: args.allow_root,
+        allow_other: args.allow_other,
         fsname,
         uid: args.uid,
         gid: args.gid,

--- a/cli/src/cmd/mount_stub.rs
+++ b/cli/src/cmd/mount_stub.rs
@@ -13,6 +13,8 @@ pub struct MountArgs {
     pub auto_unmount: bool,
     /// Allow root to access the mount.
     pub allow_root: bool,
+    /// Allow other system users to access the mount.
+    pub allow_other: bool,
     /// Run in foreground (don't daemonize).
     pub foreground: bool,
     /// User ID to report for all files (defaults to current user).

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -17,12 +17,14 @@ use std::path::PathBuf;
 mod sys;
 
 /// Handle the `run` command, dispatching to the platform-specific implementation.
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_run_command(
     allow: Vec<PathBuf>,
     no_default_allows: bool,
     experimental_sandbox: bool,
     strace: bool,
     session: Option<String>,
+    system: bool,
     command: PathBuf,
     args: Vec<String>,
 ) -> Result<()> {
@@ -32,6 +34,7 @@ pub async fn handle_run_command(
         experimental_sandbox,
         strace,
         session,
+        system,
         command,
         args,
     )

--- a/cli/src/cmd/run_darwin.rs
+++ b/cli/src/cmd/run_darwin.rs
@@ -26,12 +26,14 @@ use crate::sandbox::darwin::{generate_sandbox_profile, SandboxConfig};
 const DEFAULT_NFS_PORT: u32 = 11111;
 
 /// Run the command in a Darwin sandbox.
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     allow: Vec<PathBuf>,
     no_default_allows: bool,
     _experimental_sandbox: bool,
     _strace: bool,
     session_id: Option<String>,
+    _system: bool,
     command: PathBuf,
     args: Vec<String>,
 ) -> Result<()> {

--- a/cli/src/cmd/run_linux.rs
+++ b/cli/src/cmd/run_linux.rs
@@ -7,12 +7,14 @@ use anyhow::Result;
 use std::path::PathBuf;
 
 /// Run the command in a Linux sandbox.
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     allow: Vec<PathBuf>,
     no_default_allows: bool,
     experimental_sandbox: bool,
     strace: bool,
     session: Option<String>,
+    system: bool,
     command: PathBuf,
     args: Vec<String>,
 ) -> Result<()> {
@@ -28,7 +30,8 @@ pub async fn run(
         if strace {
             eprintln!("Warning: --strace is only supported with --experimental-sandbox, ignoring");
         }
-        crate::sandbox::linux::run_cmd(allow, no_default_allows, session, command, args).await?;
+        crate::sandbox::linux::run_cmd(allow, no_default_allows, session, system, command, args)
+            .await?;
     }
     Ok(())
 }

--- a/cli/src/cmd/run_windows.rs
+++ b/cli/src/cmd/run_windows.rs
@@ -6,12 +6,14 @@ use anyhow::{bail, Result};
 use std::path::PathBuf;
 
 /// Run the command in a Windows sandbox.
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     _allow: Vec<PathBuf>,
     _no_default_allows: bool,
     _experimental_sandbox: bool,
     _strace: bool,
     _session: Option<String>,
+    _system: bool,
     _command: PathBuf,
     _args: Vec<String>,
 ) -> Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -76,6 +76,7 @@ fn main() {
             experimental_sandbox,
             strace,
             session,
+            system,
             command,
             args,
         } => {
@@ -87,6 +88,7 @@ fn main() {
                 experimental_sandbox,
                 strace,
                 session,
+                system,
                 command,
                 args,
             )) {
@@ -99,6 +101,7 @@ fn main() {
             mountpoint,
             auto_unmount,
             allow_root,
+            system,
             foreground,
             uid,
             gid,
@@ -109,6 +112,7 @@ fn main() {
                     mountpoint,
                     auto_unmount,
                     allow_root,
+                    allow_other: system,
                     foreground,
                     uid,
                     gid,

--- a/cli/src/nfs.rs
+++ b/cli/src/nfs.rs
@@ -296,7 +296,7 @@ impl NFSFileSystem for AgentNFS {
         // Create empty file
         {
             let fs = self.fs.lock().await;
-            fs.write_file(&full_path, &[])
+            fs.write_file(&full_path, &[], 0, 0)
                 .await
                 .map_err(error_to_nfsstat)?;
         }
@@ -328,7 +328,7 @@ impl NFSFileSystem for AgentNFS {
         }
 
         // Create empty file
-        fs.write_file(&full_path, &[])
+        fs.write_file(&full_path, &[], 0, 0)
             .await
             .map_err(error_to_nfsstat)?;
 
@@ -347,7 +347,7 @@ impl NFSFileSystem for AgentNFS {
 
         {
             let fs = self.fs.lock().await;
-            fs.mkdir(&full_path).await.map_err(error_to_nfsstat)?;
+            fs.mkdir(&full_path, 0, 0).await.map_err(error_to_nfsstat)?;
         }
 
         let ino = self.inode_map.write().await.get_or_create_ino(&full_path);
@@ -466,7 +466,7 @@ impl NFSFileSystem for AgentNFS {
 
         {
             let fs = self.fs.lock().await;
-            fs.symlink(target, &full_path)
+            fs.symlink(target, &full_path, 0, 0)
                 .await
                 .map_err(error_to_nfsstat)?;
         }

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -99,6 +99,11 @@ pub enum Command {
         #[arg(long = "session", value_name = "ID")]
         session: Option<String>,
 
+        /// Allow other system users to access this mount (requires /etc/fuse.conf
+        /// user_allow_other; use cautiously)
+        #[arg(long = "system")]
+        system: bool,
+
         /// Command to execute (defaults to bash on Linux, zsh on macOS)
         command: Option<PathBuf>,
 
@@ -123,6 +128,11 @@ pub enum Command {
         /// Allow root user to access filesystem
         #[arg(long)]
         allow_root: bool,
+
+        /// Allow other system users to access this mount (requires /etc/fuse.conf
+        /// user_allow_other; use cautiously)
+        #[arg(long = "system")]
+        system: bool,
 
         /// Run in foreground (don't daemonize)
         #[arg(short = 'f', long)]

--- a/cli/src/sandbox/linux.rs
+++ b/cli/src/sandbox/linux.rs
@@ -145,6 +145,7 @@ pub async fn run_cmd(
     allow: Vec<PathBuf>,
     no_default_allows: bool,
     session_id: Option<String>,
+    system: bool,
     command: PathBuf,
     args: Vec<String>,
 ) -> Result<()> {
@@ -209,8 +210,7 @@ pub async fn run_cmd(
 
     let overlay: Arc<dyn FileSystem> = Arc::new(overlay);
 
-    // Set up FUSE mount options - mount at hidden temp directory
-    // SAFETY: getuid/getgid are always safe, they simply return the current user/group IDs
+    // SAFETY: getuid/getgid are always safe
     let uid = unsafe { libc::getuid() };
     let gid = unsafe { libc::getgid() };
 
@@ -218,6 +218,7 @@ pub async fn run_cmd(
         mountpoint: session.fuse_mountpoint.clone(),
         auto_unmount: false,
         allow_root: false,
+        allow_other: system,
         fsname: format!("agentfs:{}", session.run_id),
         uid: Some(uid),
         gid: Some(gid),

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -52,5 +52,6 @@ int test_link(const char *base_path);
 int test_unlink(const char *base_path);
 int test_copyup_inode_stability(const char *base_path);
 int test_rename(const char *base_path);
+int test_chown(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/sandbox/src/vfs/sqlite.rs
+++ b/sandbox/src/vfs/sqlite.rs
@@ -228,7 +228,7 @@ impl Vfs for SqliteVfs {
             .ok_or_else(|| VfsError::InvalidInput("Invalid target path".to_string()))?;
 
         self.fs
-            .symlink(target_str, &linkpath_rel)
+            .symlink(target_str, &linkpath_rel, 0, 0)
             .await
             .map_err(|e| {
                 let err_msg = e.to_string();
@@ -395,7 +395,7 @@ impl FileOps for SqliteFileOps {
 
         // Write the data to the database
         self.fs
-            .write_file(&self.path, &data)
+            .write_file(&self.path, &data, 0, 0)
             .await
             .map_err(|e| VfsError::Other(format!("Failed to write file: {}", e)))?;
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -639,7 +639,7 @@ mod tests {
         let agentfs = AgentFS::open(AgentFSOptions::ephemeral()).await.unwrap();
 
         // Create a directory
-        agentfs.fs.mkdir("/test_dir").await.unwrap();
+        agentfs.fs.mkdir("/test_dir", 0, 0).await.unwrap();
 
         // Check directory exists
         let stats = agentfs.fs.stat("/test_dir").await.unwrap();
@@ -650,7 +650,7 @@ mod tests {
         let data = b"Hello, AgentFS!";
         agentfs
             .fs
-            .write_file("/test_dir/test.txt", data)
+            .write_file("/test_dir/test.txt", data, 0, 0)
             .await
             .unwrap();
 


### PR DESCRIPTION
Previously, all files in the FUSE mount appeared owned by root with hardcoded uid/gid values set at mount time. This meant that operations like chown() were silently ignored, and non-root users couldn't access files even when Unix permissions should have allowed it.

This commit adds proper Unix permission semantics throughout the filesystem stack. The FileSystem trait now accepts uid/gid parameters when creating files, directories, and symlinks, allowing the FUSE layer to pass through the requesting process's credentials. A new chown() method enables changing file ownership after creation.

The FUSE mount now uses AllowOther so users other than root can access the filesystem, and DefaultPermissions to let the kernel enforce permission checks based on the actual file mode and ownership. The setattr handler implements chown by delegating to the new FileSystem method.

For OverlayFS, copy-on-write operations now preserve the original file's ownership when copying from base to delta layer. This ensures that permission semantics remain consistent even after modifications trigger a copy-up.