### PR TITLE
fix: add missing `system` parameter to run_not_supported.rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,23 @@ jobs:
     - name: Check
       run: cargo check --all-features
 
+  check-no-default-features:
+    name: Check no-default-features (cli)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly
+
+    - name: Check with no default features
+      run: cargo check --no-default-features
+
   build-linux-arm64:
     name: Build (Linux arm64)
     runs-on: ubuntu-24.04-arm

--- a/cli/src/cmd/run_not_supported.rs
+++ b/cli/src/cmd/run_not_supported.rs
@@ -12,6 +12,7 @@ pub async fn run(
     _experimental_sandbox: bool,
     _strace: bool,
     _session: Option<String>,
+    _system: bool,
     _command: PathBuf,
     _args: Vec<String>,
 ) -> Result<()> {


### PR DESCRIPTION
## Summary

Commit 68a9d1d3 added a `system` parameter to the run command but didn't update `run_not_supported.rs`, causing builds with `--no-default-features` to fail:

```
error[E0061]: this function takes 7 arguments but 8 arguments were supplied
  --> src/cmd/run.rs:31:5
   |
31 |     sys::run(
   |     ^^^^^^^^
...
37 |         system,
   |         ------ unexpected argument #6 of type `bool`
```

## Changes

1. Added the missing `_system: bool` parameter to `run_not_supported.rs`
2. Added a CI job to check that the code compiles with `--no-default-features` to prevent similar regressions

Fixes #256