### PR TITLE
Add POSIX special file support

### DIFF
--- a/cli/tests/syscall/Makefile
+++ b/cli/tests/syscall/Makefile
@@ -19,7 +19,9 @@ SRCS = main.c \
        test-link.c \
        test-unlink.c \
        test-copyup-inode-stability.c \
-       test-rename.c
+       test-rename.c \
+       test-mknod.c \
+       test-mkfifo.c
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/cli/tests/syscall/main.c
+++ b/cli/tests/syscall/main.c
@@ -35,6 +35,8 @@ int main(int argc, char *argv[]) {
         {"unlink", test_unlink},
         {"copyup_inode_stability", test_copyup_inode_stability},
         {"rename", test_rename},
+        {"mknod", test_mknod},
+        {"mkfifo", test_mkfifo},
     };
 
     int num_tests = sizeof(tests) / sizeof(tests[0]);

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -53,5 +53,7 @@ int test_unlink(const char *base_path);
 int test_copyup_inode_stability(const char *base_path);
 int test_rename(const char *base_path);
 int test_chown(const char *base_path);
+int test_mknod(const char *base_path);
+int test_mkfifo(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/cli/tests/syscall/test-mkfifo.c
+++ b/cli/tests/syscall/test-mkfifo.c
@@ -1,0 +1,145 @@
+#define _GNU_SOURCE
+#include "test-common.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int test_mkfifo(const char *base_path) {
+    char path[512];
+    struct stat st;
+    int result;
+    mode_t old_umask;
+
+    /* Save and clear umask for predictable permission tests */
+    old_umask = umask(0);
+
+    /* Test 1: Create a FIFO (named pipe) using mkfifo */
+    snprintf(path, sizeof(path), "%s/test_fifo_mkfifo", base_path);
+    unlink(path);  /* Clean up any previous test file */
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo creation should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT(S_ISFIFO(st.st_mode), "created node should be a FIFO");
+    TEST_ASSERT((st.st_mode & 0777) == 0644, "FIFO should have correct permissions (0644)");
+
+    unlink(path);
+
+    /* Test 2: mkfifo with existing path should fail with EEXIST */
+    snprintf(path, sizeof(path), "%s/test.txt", base_path);
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT(result < 0, "mkfifo on existing file should fail");
+    TEST_ASSERT(errno == EEXIST, "errno should be EEXIST for existing path");
+
+    /* Test 3: mkfifo in non-existent directory should fail with ENOENT */
+    snprintf(path, sizeof(path), "%s/nonexistent_dir/test_mkfifo", base_path);
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT(result < 0, "mkfifo in non-existent directory should fail");
+    TEST_ASSERT(errno == ENOENT, "errno should be ENOENT for non-existent directory");
+
+    /* Test 4: Create a FIFO with different permissions (0755) */
+    snprintf(path, sizeof(path), "%s/test_fifo_perms_755", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0755);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo with 0755 should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT((st.st_mode & 0777) == 0755, "FIFO should have 0755 permissions");
+
+    unlink(path);
+
+    /* Test 5: Create a FIFO with restrictive permissions (0600) */
+    snprintf(path, sizeof(path), "%s/test_fifo_perms_600", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0600);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo with 0600 should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT((st.st_mode & 0777) == 0600, "FIFO should have 0600 permissions");
+
+    unlink(path);
+
+    /* Test 6: Create FIFO in subdirectory */
+    char subdir_path[512];
+    snprintf(subdir_path, sizeof(subdir_path), "%s/mkfifo_subdir", base_path);
+    mkdir(subdir_path, 0755);
+
+    snprintf(path, sizeof(path), "%s/mkfifo_subdir/test_fifo", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo in subdirectory should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO in subdirectory should succeed");
+    TEST_ASSERT(S_ISFIFO(st.st_mode), "created node in subdir should be a FIFO");
+
+    unlink(path);
+    rmdir(subdir_path);
+
+    /* Test 7: Create FIFO and verify it has size 0 */
+    snprintf(path, sizeof(path), "%s/test_fifo_size", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT(st.st_size == 0, "FIFO should have size 0");
+
+    unlink(path);
+
+    /* Test 8: Create FIFO and verify link count is 1 */
+    snprintf(path, sizeof(path), "%s/test_fifo_nlink", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT(st.st_nlink == 1, "FIFO should have nlink == 1");
+
+    unlink(path);
+
+    /* Test 9: Create FIFO with world-writable permissions (0666) */
+    snprintf(path, sizeof(path), "%s/test_fifo_666", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0666);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo with 0666 should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT((st.st_mode & 0777) == 0666, "FIFO should have 0666 permissions");
+
+    unlink(path);
+
+    /* Test 10: Verify FIFO shows up in directory listing */
+    snprintf(path, sizeof(path), "%s/test_fifo_readdir", base_path);
+    unlink(path);
+
+    result = mkfifo(path, 0644);
+    TEST_ASSERT_ERRNO(result == 0, "mkfifo should succeed");
+
+    /* Verify file exists via lstat too */
+    result = lstat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "lstat on FIFO should succeed");
+    TEST_ASSERT(S_ISFIFO(st.st_mode), "lstat should report FIFO type");
+
+    unlink(path);
+
+    /* Restore original umask */
+    umask(old_umask);
+
+    return 0;
+}

--- a/cli/tests/syscall/test-mknod.c
+++ b/cli/tests/syscall/test-mknod.c
@@ -1,0 +1,140 @@
+#define _GNU_SOURCE
+#include "test-common.h"
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int test_mknod(const char *base_path) {
+    char path[512];
+    struct stat st;
+    int result;
+
+    /* Test 1: Create a FIFO (named pipe) using mknod */
+    snprintf(path, sizeof(path), "%s/test_fifo_mknod", base_path);
+    unlink(path);  /* Clean up any previous test file */
+
+    result = mknod(path, S_IFIFO | 0644, 0);
+    TEST_ASSERT_ERRNO(result == 0, "mknod FIFO creation should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT(S_ISFIFO(st.st_mode), "created node should be a FIFO");
+    TEST_ASSERT((st.st_mode & 0777) == 0644, "FIFO should have correct permissions");
+
+    unlink(path);
+
+    /* Test 2: Create a regular file using mknod */
+    snprintf(path, sizeof(path), "%s/test_file_mknod", base_path);
+    unlink(path);
+
+    result = mknod(path, S_IFREG | 0600, 0);
+    TEST_ASSERT_ERRNO(result == 0, "mknod regular file creation should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on regular file should succeed");
+    TEST_ASSERT(S_ISREG(st.st_mode), "created node should be a regular file");
+    TEST_ASSERT((st.st_mode & 0777) == 0600, "regular file should have correct permissions");
+
+    unlink(path);
+
+    /* Test 3: mknod with existing path should fail with EEXIST */
+    snprintf(path, sizeof(path), "%s/test.txt", base_path);
+
+    result = mknod(path, S_IFREG | 0644, 0);
+    TEST_ASSERT(result < 0, "mknod on existing file should fail");
+    TEST_ASSERT(errno == EEXIST, "errno should be EEXIST for existing path");
+
+    /* Test 4: mknod in non-existent directory should fail with ENOENT */
+    snprintf(path, sizeof(path), "%s/nonexistent_dir/test_mknod", base_path);
+
+    result = mknod(path, S_IFREG | 0644, 0);
+    TEST_ASSERT(result < 0, "mknod in non-existent directory should fail");
+    TEST_ASSERT(errno == ENOENT, "errno should be ENOENT for non-existent directory");
+
+    /* Test 5: Create a FIFO with different permissions */
+    snprintf(path, sizeof(path), "%s/test_fifo_perms", base_path);
+    unlink(path);
+
+    result = mknod(path, S_IFIFO | 0755, 0);
+    TEST_ASSERT_ERRNO(result == 0, "mknod FIFO with 0755 should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO should succeed");
+    TEST_ASSERT((st.st_mode & 0777) == 0755, "FIFO should have 0755 permissions");
+
+    unlink(path);
+
+    /* Test 6: Create FIFO in subdirectory */
+    char subdir_path[512];
+    snprintf(subdir_path, sizeof(subdir_path), "%s/subdir", base_path);
+    mkdir(subdir_path, 0755);
+
+    snprintf(path, sizeof(path), "%s/subdir/test_fifo_subdir", base_path);
+    unlink(path);
+
+    result = mknod(path, S_IFIFO | 0644, 0);
+    TEST_ASSERT_ERRNO(result == 0, "mknod FIFO in subdirectory should succeed");
+
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat on FIFO in subdirectory should succeed");
+    TEST_ASSERT(S_ISFIFO(st.st_mode), "created node in subdir should be a FIFO");
+
+    unlink(path);
+
+    /* Test 7: Character device creation (may require CAP_MKNOD) */
+    snprintf(path, sizeof(path), "%s/test_chrdev", base_path);
+    unlink(path);
+
+    result = mknod(path, S_IFCHR | 0666, makedev(1, 3));  /* /dev/null major/minor */
+    if (result < 0 && (errno == EPERM || errno == EACCES)) {
+        printf("  (Skipping device node tests - requires CAP_MKNOD)\n");
+    } else if (result == 0) {
+        result = stat(path, &st);
+        TEST_ASSERT_ERRNO(result == 0, "stat on character device should succeed");
+        TEST_ASSERT(S_ISCHR(st.st_mode), "created node should be a character device");
+        TEST_ASSERT(major(st.st_rdev) == 1, "character device should have correct major number");
+        TEST_ASSERT(minor(st.st_rdev) == 3, "character device should have correct minor number");
+        unlink(path);
+    }
+
+    /* Test 8: Block device creation (may require CAP_MKNOD) */
+    snprintf(path, sizeof(path), "%s/test_blkdev", base_path);
+    unlink(path);
+
+    result = mknod(path, S_IFBLK | 0666, makedev(7, 0));  /* loop0 major/minor */
+    if (result < 0 && (errno == EPERM || errno == EACCES)) {
+        /* Expected without CAP_MKNOD - already noted above */
+    } else if (result == 0) {
+        result = stat(path, &st);
+        TEST_ASSERT_ERRNO(result == 0, "stat on block device should succeed");
+        TEST_ASSERT(S_ISBLK(st.st_mode), "created node should be a block device");
+        TEST_ASSERT(major(st.st_rdev) == 7, "block device should have correct major number");
+        TEST_ASSERT(minor(st.st_rdev) == 0, "block device should have correct minor number");
+        unlink(path);
+    }
+
+    /* Test 9: Socket creation via mknod is typically not supported */
+    snprintf(path, sizeof(path), "%s/test_socket_mknod", base_path);
+    unlink(path);
+
+    result = mknod(path, S_IFSOCK | 0644, 0);
+    /* Socket creation via mknod may fail with EOPNOTSUPP or succeed depending on FS */
+    if (result == 0) {
+        result = stat(path, &st);
+        TEST_ASSERT_ERRNO(result == 0, "stat on socket should succeed");
+        TEST_ASSERT(S_ISSOCK(st.st_mode), "created node should be a socket");
+        unlink(path);
+    } else {
+        /* EOPNOTSUPP, EPERM, or other errors are acceptable for sockets */
+        printf("  (Socket creation via mknod returned errno=%d: %s - this is acceptable)\n",
+               errno, strerror(errno));
+    }
+
+    /* Test 10: Empty filename should fail */
+    snprintf(path, sizeof(path), "%s/", base_path);
+    result = mknod(path, S_IFREG | 0644, 0);
+    TEST_ASSERT(result < 0, "mknod with empty filename should fail");
+
+    return 0;
+}

--- a/sdk/rust/benches/workload.rs
+++ b/sdk/rust/benches/workload.rs
@@ -307,13 +307,13 @@ async fn execute_operation(overlay: &OverlayFS, op: Operation, path: &str) {
     match op {
         Operation::CreateFile => {
             // Ignore errors - path may not exist, which is expected
-            let _ = overlay.create_file(path, 0o100644).await;
+            let _ = overlay.create_file(path, 0o100644, 0, 0).await;
         }
         Operation::Lstat => {
             let _ = overlay.lstat(path).await;
         }
         Operation::Mkdir => {
-            let _ = overlay.mkdir(path).await;
+            let _ = overlay.mkdir(path, 0, 0).await;
         }
         Operation::Open => {
             let _ = overlay.open(path).await;


### PR DESCRIPTION
This commit adds support for POSIX special files throughout the filesystem stack. The FileSystem trait now includes a mknod() method that accepts mode (containing file type and permissions) and rdev (device major/minor numbers for character and block devices). A new rdev field in the Stats struct stores device numbers, and new file type constants (S_IFIFO, S_IFCHR, S_IFBLK, S_IFSOCK) are exported for use by implementations.

The FUSE layer implements mknod() by delegating to the FileSystem trait and properly returning entry attributes after creation. The fillattr() function now maps all file types (FIFO, character device, block device, socket) to their corresponding FUSE FileType variants instead of treating everything as regular files.

For AgentFS (SQLite-based storage), the fs_inode table gains an rdev column to persist device numbers. The mknod implementation creates inodes with the appropriate mode bits and device numbers, following the same pattern as file and directory creation.

HostFS passes through to the libc mknod() call for native filesystem support. OverlayFS implements copy-on-write semantics for special files, checking both layers and handling whiteouts before creating in the delta layer.

Also add some syscall tests verify mknod() and mkfifo() behavior including FIFO creation, permission handling, error cases (EEXIST, ENOENT), and device node creation when CAP_MKNOD is available.