### PR TITLE
sdk/rust: Fix overlayfs permissions copy-up

### DIFF
--- a/cli/src/nfs.rs
+++ b/cli/src/nfs.rs
@@ -296,7 +296,8 @@ impl NFSFileSystem for AgentNFS {
         // Create empty file
         {
             let fs = self.fs.lock().await;
-            fs.write_file(&full_path, &[], 0, 0)
+            let _ = fs
+                .create_file(&full_path, S_IFREG | 0o644, 0, 0)
                 .await
                 .map_err(error_to_nfsstat)?;
         }
@@ -328,7 +329,8 @@ impl NFSFileSystem for AgentNFS {
         }
 
         // Create empty file
-        fs.write_file(&full_path, &[], 0, 0)
+        let _ = fs
+            .create_file(&full_path, S_IFREG | 0o644, 0, 0)
             .await
             .map_err(error_to_nfsstat)?;
 

--- a/cli/tests/syscall/Makefile
+++ b/cli/tests/syscall/Makefile
@@ -21,7 +21,8 @@ SRCS = main.c \
        test-copyup-inode-stability.c \
        test-rename.c \
        test-mknod.c \
-       test-mkfifo.c
+       test-mkfifo.c \
+       test-copyup-permissions.c
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/cli/tests/syscall/main.c
+++ b/cli/tests/syscall/main.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[]) {
         {"rename", test_rename},
         {"mknod", test_mknod},
         {"mkfifo", test_mkfifo},
+        {"copyup_permissions", test_copyup_permissions},
     };
 
     int num_tests = sizeof(tests) / sizeof(tests[0]);

--- a/cli/tests/syscall/test-common.h
+++ b/cli/tests/syscall/test-common.h
@@ -55,5 +55,6 @@ int test_rename(const char *base_path);
 int test_chown(const char *base_path);
 int test_mknod(const char *base_path);
 int test_mkfifo(const char *base_path);
+int test_copyup_permissions(const char *base_path);
 
 #endif /* TEST_COMMON_H */

--- a/cli/tests/syscall/test-copyup-permissions.c
+++ b/cli/tests/syscall/test-copyup-permissions.c
@@ -1,0 +1,97 @@
+#define _GNU_SOURCE
+#include "test-common.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/**
+ * Test that copy-up preserves base layer file permissions.
+ *
+ * When a file is copied from the base layer to the delta layer (copy-up),
+ * its permissions must be preserved. This test uses a file that was created
+ * in the base layer (by the test shell script) with mode 0755.
+ *
+ * The bug: copy-up code was using DEFAULT_FILE_MODE (0644) instead of
+ * preserving the original stats.mode from the base layer.
+ *
+ * Test setup (in test-run-syscalls.sh):
+ *   echo -n "executable content" > executable_base.txt
+ *   chmod 0755 executable_base.txt
+ *
+ * The test:
+ * 1. Verifies the base layer file has mode 0755
+ * 2. Writes to the file (triggers copy-up to delta layer)
+ * 3. Verifies that permissions are still 0755 after copy-up
+ */
+
+int test_copyup_permissions(const char *base_path) {
+    char file_path[512];
+    struct stat st_before, st_after;
+    int result, fd;
+    mode_t mode_before, mode_after;
+
+    snprintf(file_path, sizeof(file_path), "%s/executable_base.txt", base_path);
+
+    /*
+     * Test 1: Verify the base layer file exists and has mode 0755.
+     * This file was created by the test shell script before mounting the overlay.
+     */
+    result = stat(file_path, &st_before);
+    if (result < 0 && errno == ENOENT) {
+        printf("  (Skipping copy-up permissions test - executable_base.txt not in base layer)\n");
+        return 0;
+    }
+    TEST_ASSERT_ERRNO(result == 0, "stat on base layer file should succeed");
+
+    mode_before = st_before.st_mode & 07777;  /* Extract permission bits only */
+    if (mode_before != 0755) {
+        fprintf(stderr, "  base layer mode: expected 0755, got %04o\n", mode_before);
+        fprintf(stderr, "  (test requires executable_base.txt with mode 0755 in base layer)\n");
+    }
+    TEST_ASSERT(mode_before == 0755, "base layer file should have mode 0755");
+
+    /*
+     * Test 2: Write to the file to trigger copy-up.
+     * In the overlay filesystem, this causes the file to be copied from
+     * the base layer to the delta layer. The bug was that copy-up used
+     * DEFAULT_FILE_MODE (0644) instead of preserving the original mode.
+     */
+    fd = open(file_path, O_WRONLY | O_APPEND);
+    TEST_ASSERT_ERRNO(fd >= 0, "open base layer file for append should succeed");
+    result = write(fd, " appended", 9);
+    TEST_ASSERT_ERRNO(result == 9, "append to base layer file should succeed");
+    close(fd);
+
+    /*
+     * Test 3: THE CRITICAL TEST - verify permissions after copy-up.
+     * The mode must be 0755 (same as the base layer file), NOT 0644.
+     */
+    result = stat(file_path, &st_after);
+    TEST_ASSERT_ERRNO(result == 0, "stat after copy-up should succeed");
+
+    mode_after = st_after.st_mode & 07777;
+    if (mode_after != mode_before) {
+        fprintf(stderr, "  COPY-UP PERMISSION BUG: mode changed from %04o to %04o\n",
+                mode_before, mode_after);
+        fprintf(stderr, "  Expected: %04o (preserved from base layer)\n", mode_before);
+        fprintf(stderr, "  Got:      %04o (likely DEFAULT_FILE_MODE)\n", mode_after);
+    }
+    TEST_ASSERT(mode_after == mode_before,
+        "file permissions must be preserved after copy-up (was 0755, should still be 0755)");
+
+    /*
+     * Test 4: Also verify via fstat on open file descriptor.
+     */
+    fd = open(file_path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open copied-up file should succeed");
+
+    result = fstat(fd, &st_after);
+    TEST_ASSERT_ERRNO(result == 0, "fstat on copied-up file should succeed");
+
+    mode_after = st_after.st_mode & 07777;
+    TEST_ASSERT(mode_after == mode_before,
+        "fstat must also show preserved permissions after copy-up");
+    close(fd);
+
+    return 0;
+}

--- a/sdk/rust/src/filesystem/hostfs.rs
+++ b/sdk/rust/src/filesystem/hostfs.rs
@@ -182,12 +182,6 @@ impl FileSystem for HostFS {
         }
     }
 
-    async fn write_file(&self, path: &str, data: &[u8], _uid: u32, _gid: u32) -> Result<()> {
-        let full_path = self.resolve_path(path);
-        fs::write(&full_path, data).await?;
-        Ok(())
-    }
-
     async fn readdir(&self, path: &str) -> Result<Option<Vec<String>>> {
         let full_path = self.resolve_path(path);
         let mut entries = Vec::new();
@@ -400,11 +394,13 @@ impl FileSystem for HostFS {
         &self,
         path: &str,
         mode: u32,
-        uid: u32,
-        gid: u32,
+        _uid: u32,
+        _gid: u32,
     ) -> Result<(Stats, BoxedFile)> {
-        // Fallback implementation for HostFS
-        self.write_file(path, &[], uid, gid).await?;
+        let full_path = self.resolve_path(path);
+        // Create empty file
+        fs::File::create(&full_path).await?;
+        // Set permissions
         self.chmod(path, mode).await?;
         let stats = self.stat(path).await?.ok_or(FsError::NotFound)?;
         let file = self.open(path).await?;
@@ -415,6 +411,7 @@ impl FileSystem for HostFS {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DEFAULT_FILE_MODE;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -423,7 +420,8 @@ mod tests {
         let fs = HostFS::new(dir.path())?;
 
         // Write a file
-        fs.write_file("/test.txt", b"hello world", 0, 0).await?;
+        let (_, file) = fs.create_file("/test.txt", DEFAULT_FILE_MODE, 0, 0).await?;
+        file.pwrite(0, b"hello world").await?;
 
         // Read it back
         let data = fs.read_file("/test.txt").await?.unwrap();
@@ -445,9 +443,15 @@ mod tests {
         // Create directory
         fs.mkdir("/subdir", 0, 0).await?;
 
-        // Create files
-        fs.write_file("/subdir/a.txt", b"a", 0, 0).await?;
-        fs.write_file("/subdir/b.txt", b"b", 0, 0).await?;
+        // Create files using create_file + pwrite
+        let (_, file_a) = fs
+            .create_file("/subdir/a.txt", DEFAULT_FILE_MODE, 0, 0)
+            .await?;
+        file_a.pwrite(0, b"a").await?;
+        let (_, file_b) = fs
+            .create_file("/subdir/b.txt", DEFAULT_FILE_MODE, 0, 0)
+            .await?;
+        file_b.pwrite(0, b"b").await?;
 
         // List directory
         let entries = fs.readdir("/subdir").await?.unwrap();
@@ -461,8 +465,9 @@ mod tests {
         let dir = tempdir()?;
         let fs = HostFS::new(dir.path())?;
 
-        // Write initial data
-        fs.write_file("/test.txt", b"hello world", 0, 0).await?;
+        // Write initial data using create_file + pwrite
+        let (_, file) = fs.create_file("/test.txt", DEFAULT_FILE_MODE, 0, 0).await?;
+        file.pwrite(0, b"hello world").await?;
 
         // Open file handle
         let file = fs.open("/test.txt").await?;
@@ -484,8 +489,9 @@ mod tests {
         let dir = tempdir()?;
         let fs = HostFS::new(dir.path())?;
 
-        // Create a file
-        fs.write_file("/test.txt", b"content", 0, 0).await?;
+        // Create a file using create_file + pwrite
+        let (_, file) = fs.create_file("/test.txt", DEFAULT_FILE_MODE, 0, 0).await?;
+        file.pwrite(0, b"content").await?;
 
         // Change to executable
         fs.chmod("/test.txt", 0o755).await?;

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -167,12 +167,6 @@ pub trait FileSystem: Send + Sync {
     /// Returns `Ok(None)` if the file does not exist.
     async fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>>;
 
-    /// Write data to a file (creates or overwrites)
-    ///
-    /// If the file doesn't exist, it will be created with the specified uid/gid.
-    /// If the file exists, uid/gid are ignored (existing ownership preserved).
-    async fn write_file(&self, path: &str, data: &[u8], uid: u32, gid: u32) -> Result<()>;
-
     /// List directory contents
     ///
     /// Returns `Ok(None)` if the directory does not exist.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -697,11 +697,12 @@ mod tests {
 
         // Write a file
         let data = b"Hello, AgentFS!";
-        agentfs
+        let (_, file) = agentfs
             .fs
-            .write_file("/test_dir/test.txt", data, 0, 0)
+            .create_file("/test_dir/test.txt", DEFAULT_FILE_MODE, 0, 0)
             .await
             .unwrap();
+        file.pwrite(0, data).await.unwrap();
 
         // Read the file
         let read_data = agentfs


### PR DESCRIPTION
When we copy-up a file from base, let's make sure we preserve permissions, including file mode. Fixes a problem where `cargo build` would fail for build scripts (that are actually just executables) that exist already in base.