### PR TITLE
agentfs mount: Add '--backend' option

### DIFF
--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -6,9 +6,9 @@ pub mod ps;
 pub mod sync;
 pub mod timeline;
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 pub mod mount;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 #[path = "mount_stub.rs"]
 pub mod mount;
 
@@ -18,5 +18,5 @@ mod run;
 #[cfg(unix)]
 pub mod nfs;
 
-pub use mount::{mount, MountArgs};
+pub use mount::{mount, MountArgs, MountBackend};
 pub use run::handle_run_command;

--- a/cli/src/cmd/mount_stub.rs
+++ b/cli/src/cmd/mount_stub.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use std::{io::Write, path::PathBuf};
 
+pub use crate::parser::MountBackend;
+
 /// Arguments for the mount command.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -21,19 +23,21 @@ pub struct MountArgs {
     pub uid: Option<u32>,
     /// Group ID to report for all files (defaults to current group).
     pub gid: Option<u32>,
+    /// The mount backend to use (fuse or nfs).
+    pub backend: MountBackend,
 }
 
 /// List all currently mounted agentfs filesystems
 pub fn list_mounts<W: Write>(out: &mut W) {
-    let _ = writeln!(out, "Mount listing is only available on Linux.");
+    let _ = writeln!(out, "Mount listing is only available on Unix.");
 }
 
-/// Mount the agent filesystem using FUSE.
+/// Mount the agent filesystem.
 pub fn mount(_args: MountArgs) -> Result<()> {
-    anyhow::bail!("FUSE mount is only available on Linux")
+    anyhow::bail!("Mounting is only available on Unix (Linux or macOS)")
 }
 
 /// Prune unused agentfs mount points.
 pub fn prune_mounts(_force: bool) -> Result<()> {
-    anyhow::bail!("Mount pruning is only available on Linux")
+    anyhow::bail!("Mount pruning is only available on Unix")
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,6 +136,7 @@ fn main() {
             foreground,
             uid,
             gid,
+            backend,
         } => match (id_or_path, mountpoint) {
             (Some(id_or_path), Some(mountpoint)) => {
                 if let Err(e) = cmd::mount(cmd::MountArgs {
@@ -147,6 +148,7 @@ fn main() {
                     foreground,
                     uid,
                     gid,
+                    backend,
                 }) {
                     eprintln!("Error: {}", e);
                     std::process::exit(1);


### PR DESCRIPTION
This adds a `--backend` option to `agentfs mount`, which allows users to optionally select NFS on Linux.