### PR TITLE
Fix overlay filesystem whiteout persistence across mounts

### DIFF
--- a/cli/src/cmd/exec.rs
+++ b/cli/src/cmd/exec.rs
@@ -63,7 +63,7 @@ pub async fn handle_exec_command(
         if let Some(base_path) = base_path {
             eprintln!("Using overlay filesystem with base: {}", base_path);
             let hostfs = HostFS::new(&base_path)?;
-            let overlay = OverlayFS::new(Arc::new(hostfs), agentfs.fs);
+            let overlay = OverlayFS::open(Arc::new(hostfs), agentfs.fs).await?;
             Arc::new(Mutex::new(overlay)) as Arc<Mutex<dyn FileSystem + Send>>
         } else {
             Arc::new(Mutex::new(agentfs.fs)) as Arc<Mutex<dyn FileSystem + Send>>

--- a/cli/src/cmd/init.rs
+++ b/cli/src/cmd/init.rs
@@ -219,7 +219,7 @@ async fn run_init_cmd(
             .canonicalize()
             .context("Failed to canonicalize base path")?;
         let hostfs = HostFS::new(&canonical)?;
-        let overlay = OverlayFS::new(Arc::new(hostfs), agent.fs);
+        let overlay = OverlayFS::open(Arc::new(hostfs), agent.fs).await?;
         Arc::new(Mutex::new(overlay)) as Arc<Mutex<dyn FileSystem + Send>>
     } else {
         Arc::new(Mutex::new(agent.fs)) as Arc<Mutex<dyn FileSystem + Send>>

--- a/cli/src/cmd/nfs.rs
+++ b/cli/src/cmd/nfs.rs
@@ -38,7 +38,7 @@ pub async fn handle_nfs_command(id_or_path: String, bind: String, port: u32) -> 
     // Create filesystem - either direct AgentFS or overlay with base
     let fs: Arc<Mutex<dyn FileSystem>> = if let Some(base_str) = base_path {
         let hostfs = HostFS::new(&base_str).context("Failed to create HostFS")?;
-        let overlay = OverlayFS::new(Arc::new(hostfs), agentfs.fs);
+        let overlay = OverlayFS::open(Arc::new(hostfs), agentfs.fs).await?;
 
         eprintln!("Mode: overlay (base: {})", base_str);
         Arc::new(Mutex::new(overlay))

--- a/cli/tests/all.sh
+++ b/cli/tests/all.sh
@@ -20,4 +20,5 @@ DIR="$(dirname "$0")"
 "$DIR/test-run-bash.sh" || true  # Requires user namespaces (may fail in CI)
 "$DIR/test-run-git.sh" || true  # Requires user namespaces (may fail in CI)
 "$DIR/test-mount.sh"
+"$DIR/test-overlay-whiteout.sh"
 "$DIR/test-symlinks.sh" || true  # Requires user namespaces (may fail in CI)

--- a/cli/tests/test-overlay-whiteout.sh
+++ b/cli/tests/test-overlay-whiteout.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+set -e
+
+echo -n "TEST overlay whiteout persistence... "
+
+TEST_AGENT_ID="test-overlay-whiteout-agent"
+MOUNTPOINT="/tmp/agentfs-test-overlay-mount-$$"
+BASEDIR="/tmp/agentfs-test-overlay-base-$$"
+
+cleanup() {
+    # Unmount if mounted
+    fusermount -u "$MOUNTPOINT" 2>/dev/null || true
+    # Remove directories
+    rm -rf "$MOUNTPOINT" "$BASEDIR" 2>/dev/null || true
+    # Remove test database
+    rm -f ".agentfs/${TEST_AGENT_ID}.db" ".agentfs/${TEST_AGENT_ID}.db-shm" ".agentfs/${TEST_AGENT_ID}.db-wal"
+}
+
+# Ensure cleanup on exit
+trap cleanup EXIT
+
+# Clean up any existing test artifacts
+cleanup
+
+# Create base directory with a test file
+mkdir -p "$BASEDIR"
+echo "original content" > "$BASEDIR/testfile.txt"
+
+# Initialize the database with --base for overlay
+if ! output=$(cargo run -- init "$TEST_AGENT_ID" --base "$BASEDIR" 2>&1); then
+    echo "FAILED: init with --base failed"
+    echo "Output was: $output"
+    exit 1
+fi
+
+# Create mountpoint
+mkdir -p "$MOUNTPOINT"
+
+# Mount in foreground mode (background it ourselves so we can control it)
+cargo run -- mount ".agentfs/${TEST_AGENT_ID}.db" "$MOUNTPOINT" --foreground &
+MOUNT_PID=$!
+
+# Wait for mount to be ready
+MAX_WAIT=10
+WAITED=0
+while [ $WAITED -lt $MAX_WAIT ]; do
+    if mountpoint -q "$MOUNTPOINT" 2>/dev/null; then
+        break
+    fi
+    sleep 0.5
+    WAITED=$((WAITED + 1))
+done
+
+if ! mountpoint -q "$MOUNTPOINT" 2>/dev/null; then
+    echo "FAILED: mount did not become ready in time"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+# Verify base file is visible through overlay
+if [ ! -f "$MOUNTPOINT/testfile.txt" ]; then
+    echo "FAILED: base file not visible through overlay"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+CONTENT=$(cat "$MOUNTPOINT/testfile.txt")
+if [ "$CONTENT" != "original content" ]; then
+    echo "FAILED: base file content mismatch"
+    echo "Expected: original content"
+    echo "Got: $CONTENT"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+# Delete the file through the overlay
+rm "$MOUNTPOINT/testfile.txt"
+
+# Verify file is deleted
+if [ -f "$MOUNTPOINT/testfile.txt" ]; then
+    echo "FAILED: file still exists after deletion"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+# Unmount
+fusermount -u "$MOUNTPOINT"
+wait $MOUNT_PID 2>/dev/null || true
+
+# Remount to test persistence
+cargo run -- mount ".agentfs/${TEST_AGENT_ID}.db" "$MOUNTPOINT" --foreground &
+MOUNT_PID=$!
+
+# Wait for mount to be ready
+WAITED=0
+while [ $WAITED -lt $MAX_WAIT ]; do
+    if mountpoint -q "$MOUNTPOINT" 2>/dev/null; then
+        break
+    fi
+    sleep 0.5
+    WAITED=$((WAITED + 1))
+done
+
+if ! mountpoint -q "$MOUNTPOINT" 2>/dev/null; then
+    echo "FAILED: remount did not become ready in time"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+# Verify file is still deleted after remount (whiteout was persisted)
+if [ -f "$MOUNTPOINT/testfile.txt" ]; then
+    echo "FAILED: deleted file reappeared after remount (whiteout not persisted)"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+# Verify base file still exists in original location (untouched)
+if [ ! -f "$BASEDIR/testfile.txt" ]; then
+    echo "FAILED: base file was modified (should be untouched)"
+    kill $MOUNT_PID 2>/dev/null || true
+    exit 1
+fi
+
+# Unmount
+fusermount -u "$MOUNTPOINT"
+wait $MOUNT_PID 2>/dev/null || true
+
+echo "OK"


### PR DESCRIPTION
## Summary

- Fix file deletions not persisting across mount/unmount cycles when using overlay filesystem (`agentfs init --base`)
- Add `OverlayFS::open()` async constructor that automatically loads whiteouts from the database
- Add unit and integration tests for whiteout persistence

## Problem

When using `agentfs init --base` to create an overlay filesystem, file deletions were not persisted across mount/unmount cycles. A deleted file would reappear after remounting.

**Root cause:** The OverlayFS stores whiteouts (deletion markers) in both the SQLite database (`fs_whiteout` table) and an in-memory cache. When remounting, the whiteouts were not being loaded from the database into the cache.

## Solution

Added `OverlayFS::open()` - an async constructor that automatically loads whiteouts from the database. This mirrors the `AgentFS::new()` pattern which is also async and handles initialization.

**Why a new `open()` method instead of modifying `new()`?**

1. `new()` is synchronous - loading whiteouts requires async database access
2. `new()` + `init()` is still needed for creating new overlays (to set up the schema)
3. `open()` provides a clear, ergonomic API for the common case of mounting existing overlays
4. Follows the established pattern in the codebase (`AgentFS::new()` is async)

**Usage:**
```rust
// For mounting existing overlay (loads whiteouts automatically):
let overlay = OverlayFS::open(base, delta).await?;

// For creating new overlay (need to call init() to create schema):
let overlay = OverlayFS::new(base, delta);
overlay.init(base_path).await?;
```

## Test plan

- [x] Added unit test `test_overlay_whiteout_persistence_across_instances` that verifies whiteouts are loaded when creating a new overlay instance
- [x] Added integration test `test-overlay-whiteout.sh` that tests the full mount/delete/unmount/remount cycle
- [x] All existing tests pass (101 SDK tests, 8 CLI tests)
- [x] Manual testing with reproduction script confirms fix

Fixes: https://github.com/tursodatabase/agentfs/issues/270

🤖 Generated with [Claude Code](https://claude.ai/code)