### PR TITLE
Expand copy-up inode stability tests to cover all triggering syscalls

### DIFF
--- a/cli/tests/syscall/test-copyup-inode-stability.c
+++ b/cli/tests/syscall/test-copyup-inode-stability.c
@@ -1,8 +1,11 @@
 #define _GNU_SOURCE
 #include "test-common.h"
 #include <sys/stat.h>
+#include <sys/xattr.h>
+#include <sys/time.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <utime.h>
 
 /**
  * Test for inode stability after copy-up in overlay filesystem.
@@ -12,184 +15,578 @@
  * inode after copy-up, the kernel's cache becomes inconsistent, causing
  * ENOENT errors or other failures.
  *
- * This test verifies that:
- * 1. stat() returns the same inode before and after copy-up
- * 2. Hard links to copied-up files share the same inode
- * 3. lstat() also returns consistent inodes
- * 4. Multiple hard links all report the same inode
+ * This test verifies that inode numbers remain stable when copy-up is
+ * triggered by various syscalls:
+ *   - write() / pwrite() - writing to a file
+ *   - truncate() / ftruncate() - changing file size
+ *   - chmod() / fchmod() - changing permissions
+ *   - chown() / fchown() - changing ownership
+ *   - rename() - moving/renaming a file
+ *   - link() - creating hard links
+ *   - utimes() / utimensat() - changing timestamps
+ *   - setxattr() - setting extended attributes
+ *   - fallocate() - allocating file space
+ *
+ * Test setup (in test-run-syscalls.sh):
+ *   Files named copyup_<syscall>_test.txt are created in the base layer
+ *   before the overlay is mounted.
  *
  * Related to Linux overlayfs's trusted.overlay.origin mechanism.
  */
 
-int test_copyup_inode_stability(const char *base_path) {
-    char orig_path[512], link1_path[512], link2_path[512];
-    struct stat st_before, st_after, st_link1, st_link2;
-    int result, fd;
-    ino_t original_ino;
+/*
+ * Helper: Check that inode is stable after a copy-up operation.
+ * Returns 0 on success, -1 on failure.
+ */
+static int check_inode_stable(const char *path, ino_t expected_ino, const char *op_name) {
+    struct stat st;
+    int result = stat(path, &st);
+    if (result < 0) {
+        fprintf(stderr, "  stat after %s failed: %s\n", op_name, strerror(errno));
+        return -1;
+    }
+    if (st.st_ino != expected_ino) {
+        fprintf(stderr, "  INODE CHANGED after %s: was %lu, now %lu\n",
+                op_name, (unsigned long)expected_ino, (unsigned long)st.st_ino);
+        return -1;
+    }
+    return 0;
+}
 
-    snprintf(orig_path, sizeof(orig_path), "%s/copyup_test_file.txt", base_path);
-    snprintf(link1_path, sizeof(link1_path), "%s/test_copyup_link1", base_path);
-    snprintf(link2_path, sizeof(link2_path), "%s/test_copyup_link2", base_path);
+/*
+ * Helper: Check if a file exists in the base layer (skip test if not).
+ * Returns the original inode, or 0 if the file doesn't exist.
+ */
+static ino_t get_base_layer_inode(const char *base_path, const char *filename, const char *test_name) {
+    char path[512];
+    struct stat st;
 
-    /* Clean up any previous test files */
-    unlink(link1_path);
-    unlink(link2_path);
-    unlink(orig_path);
-
-    /* Create the test file - this ensures we have a clean file for this test */
-    fd = open(orig_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    TEST_ASSERT_ERRNO(fd >= 0, "create test file should succeed");
-    result = write(fd, "copyup test content\n", 20);
-    TEST_ASSERT_ERRNO(result == 20, "write test content should succeed");
-    close(fd);
-
-    /*
-     * Test 1: Get the original inode before any copy-up operation.
-     * This file should exist in the base layer.
-     */
-    result = stat(orig_path, &st_before);
-    TEST_ASSERT_ERRNO(result == 0, "stat on original file should succeed");
-    original_ino = st_before.st_ino;
-    TEST_ASSERT(original_ino > 0, "original inode should be valid");
-
-    /*
-     * Test 2: Create a hard link to the file.
-     * In an overlay filesystem, this triggers copy-up: the file is copied
-     * from base to delta layer. The bug was that after copy-up, stat()
-     * would return the new delta inode instead of the original base inode.
-     */
-    result = link(orig_path, link1_path);
-    if (result < 0 && (errno == ENOSYS || errno == EOPNOTSUPP)) {
-        printf("  (Skipping copy-up inode stability test - link syscall not supported)\n");
+    snprintf(path, sizeof(path), "%s/%s", base_path, filename);
+    if (stat(path, &st) < 0) {
+        if (errno == ENOENT) {
+            printf("  (Skipping %s test - %s not in base layer)\n", test_name, filename);
+            return 0;
+        }
+        fprintf(stderr, "  stat on %s failed: %s\n", filename, strerror(errno));
         return 0;
     }
-    TEST_ASSERT_ERRNO(result == 0, "link() should succeed");
+    return st.st_ino;
+}
 
-    /*
-     * Test 3: THE CRITICAL TEST - stat() on original file after copy-up.
-     * The inode MUST be the same as before. If it changes, the kernel's
-     * inode cache becomes inconsistent with reality.
-     */
-    result = stat(orig_path, &st_after);
-    TEST_ASSERT_ERRNO(result == 0, "stat on original file after link should succeed");
-    if (st_after.st_ino != original_ino) {
-        fprintf(stderr, "  inode changed: was %lu, now %lu\n",
-                (unsigned long)original_ino, (unsigned long)st_after.st_ino);
+/**
+ * Test 1: write() triggered copy-up
+ *
+ * Writing to a base layer file should trigger copy-up while preserving
+ * the original inode number.
+ */
+static int test_write_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    int fd, result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_write_test.txt", "write copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_write_test.txt", base_path);
+
+    /* Open for writing and write data - this triggers copy-up */
+    fd = open(path, O_WRONLY | O_APPEND);
+    TEST_ASSERT_ERRNO(fd >= 0, "open for write should succeed");
+
+    result = write(fd, " appended data", 14);
+    TEST_ASSERT_ERRNO(result == 14, "write should succeed");
+    close(fd);
+
+    /* Verify inode is stable after copy-up */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "write") == 0,
+        "inode must remain stable after write copy-up");
+
+    /* Also verify via fstat */
+    fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open after write should succeed");
+
+    struct stat st;
+    result = fstat(fd, &st);
+    TEST_ASSERT_ERRNO(result == 0, "fstat after write should succeed");
+    TEST_ASSERT(st.st_ino == orig_ino, "fstat must return stable inode after write copy-up");
+    close(fd);
+
+    return 0;
+}
+
+/**
+ * Test 2: truncate() triggered copy-up
+ *
+ * Truncating a base layer file should trigger copy-up while preserving
+ * the original inode number.
+ */
+static int test_truncate_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    int result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_truncate_test.txt", "truncate copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_truncate_test.txt", base_path);
+
+    /* Truncate the file - this triggers copy-up */
+    result = truncate(path, 10);
+    TEST_ASSERT_ERRNO(result == 0, "truncate should succeed");
+
+    /* Verify inode is stable after copy-up */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "truncate") == 0,
+        "inode must remain stable after truncate copy-up");
+
+    /* Also test ftruncate */
+    int fd = open(path, O_WRONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open for ftruncate should succeed");
+
+    result = ftruncate(fd, 5);
+    TEST_ASSERT_ERRNO(result == 0, "ftruncate should succeed");
+
+    struct stat st;
+    result = fstat(fd, &st);
+    TEST_ASSERT_ERRNO(result == 0, "fstat after ftruncate should succeed");
+    TEST_ASSERT(st.st_ino == orig_ino, "fstat must return stable inode after ftruncate");
+    close(fd);
+
+    return 0;
+}
+
+/**
+ * Test 3: chmod() triggered copy-up
+ *
+ * Changing permissions on a base layer file should trigger copy-up
+ * while preserving the original inode number.
+ */
+static int test_chmod_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    int result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_chmod_test.txt", "chmod copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_chmod_test.txt", base_path);
+
+    /* chmod - this triggers copy-up */
+    result = chmod(path, 0755);
+    TEST_ASSERT_ERRNO(result == 0, "chmod should succeed");
+
+    /* Verify inode is stable after copy-up */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "chmod") == 0,
+        "inode must remain stable after chmod copy-up");
+
+    /* Also test fchmod */
+    int fd = open(path, O_RDONLY);
+    TEST_ASSERT_ERRNO(fd >= 0, "open for fchmod should succeed");
+
+    result = fchmod(fd, 0700);
+    TEST_ASSERT_ERRNO(result == 0, "fchmod should succeed");
+
+    struct stat st;
+    result = fstat(fd, &st);
+    TEST_ASSERT_ERRNO(result == 0, "fstat after fchmod should succeed");
+    TEST_ASSERT(st.st_ino == orig_ino, "fstat must return stable inode after fchmod");
+    close(fd);
+
+    return 0;
+}
+
+/**
+ * Test 4: chown() triggered copy-up
+ *
+ * Changing ownership on a base layer file should trigger copy-up
+ * while preserving the original inode number.
+ *
+ * Note: This may fail without root privileges, which is expected.
+ */
+static int test_chown_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    struct stat st;
+    int result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_chown_test.txt", "chown copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_chown_test.txt", base_path);
+
+    /* Get current owner */
+    result = stat(path, &st);
+    TEST_ASSERT_ERRNO(result == 0, "stat for chown should succeed");
+
+    /* chown to same user (should still trigger copy-up) */
+    result = chown(path, st.st_uid, st.st_gid);
+    if (result < 0 && (errno == EPERM || errno == ENOSYS)) {
+        printf("  (Skipping chown test - operation not permitted)\n");
+        return 0;
     }
-    TEST_ASSERT(st_after.st_ino == original_ino,
-        "inode must remain stable after copy-up");
+    TEST_ASSERT_ERRNO(result == 0, "chown should succeed");
 
-    /*
-     * Test 4: stat() on the hard link should return the same inode.
-     * Hard links by definition share the same inode.
-     */
-    result = stat(link1_path, &st_link1);
+    /* Verify inode is stable after copy-up */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "chown") == 0,
+        "inode must remain stable after chown copy-up");
+
+    /* Also test lchown */
+    result = lchown(path, st.st_uid, st.st_gid);
+    TEST_ASSERT_ERRNO(result == 0, "lchown should succeed");
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "lchown") == 0,
+        "inode must remain stable after lchown copy-up");
+
+    return 0;
+}
+
+/**
+ * Test 5: rename() triggered copy-up
+ *
+ * Renaming a base layer file should trigger copy-up while preserving
+ * the original inode number (at the new path).
+ */
+static int test_rename_copyup(const char *base_path) {
+    char orig_path[512], new_path[512];
+    ino_t orig_ino;
+    int result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_rename_test.txt", "rename copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(orig_path, sizeof(orig_path), "%s/copyup_rename_test.txt", base_path);
+    snprintf(new_path, sizeof(new_path), "%s/copyup_rename_test_renamed.txt", base_path);
+
+    /* Clean up any previous renamed file */
+    unlink(new_path);
+
+    /* rename - this triggers copy-up */
+    result = rename(orig_path, new_path);
+    TEST_ASSERT_ERRNO(result == 0, "rename should succeed");
+
+    /* The new path should have the same inode as the original */
+    TEST_ASSERT(check_inode_stable(new_path, orig_ino, "rename") == 0,
+        "inode must remain stable after rename copy-up");
+
+    /* Original path should no longer exist */
+    struct stat st;
+    result = stat(orig_path, &st);
+    TEST_ASSERT(result < 0 && errno == ENOENT,
+        "original path should not exist after rename");
+
+    /* Clean up */
+    unlink(new_path);
+
+    return 0;
+}
+
+/**
+ * Test 6: link() triggered copy-up
+ *
+ * Creating a hard link to a base layer file should trigger copy-up
+ * while preserving the original inode number for both paths.
+ */
+static int test_link_copyup(const char *base_path) {
+    char orig_path[512], link_path[512], link2_path[512];
+    struct stat st_orig, st_link;
+    ino_t orig_ino;
+    int result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_link_test.txt", "link copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(orig_path, sizeof(orig_path), "%s/copyup_link_test.txt", base_path);
+    snprintf(link_path, sizeof(link_path), "%s/copyup_link_test_hardlink.txt", base_path);
+    snprintf(link2_path, sizeof(link2_path), "%s/copyup_link_test_hardlink2.txt", base_path);
+
+    /* Clean up any previous links */
+    unlink(link_path);
+    unlink(link2_path);
+
+    /* link() - this triggers copy-up */
+    result = link(orig_path, link_path);
+    if (result < 0 && (errno == ENOSYS || errno == EOPNOTSUPP)) {
+        printf("  (Skipping link copyup test - link syscall not supported)\n");
+        return 0;
+    }
+    TEST_ASSERT_ERRNO(result == 0, "link should succeed");
+
+    /* Original file must still have the same inode */
+    TEST_ASSERT(check_inode_stable(orig_path, orig_ino, "link (original)") == 0,
+        "original inode must remain stable after link copy-up");
+
+    /* Hard link must have the same inode */
+    result = stat(link_path, &st_link);
     TEST_ASSERT_ERRNO(result == 0, "stat on hard link should succeed");
-    if (st_link1.st_ino != original_ino) {
+    if (st_link.st_ino != orig_ino) {
         fprintf(stderr, "  hard link inode mismatch: expected %lu, got %lu\n",
-                (unsigned long)original_ino, (unsigned long)st_link1.st_ino);
+                (unsigned long)orig_ino, (unsigned long)st_link.st_ino);
     }
-    TEST_ASSERT(st_link1.st_ino == original_ino,
+    TEST_ASSERT(st_link.st_ino == orig_ino,
         "hard link must have same inode as original");
 
-    /*
-     * Test 5: lstat() should also return consistent inodes.
-     * Even though these aren't symlinks, lstat() is often used and must
-     * also return the correct (original) inode.
-     */
-    result = lstat(orig_path, &st_after);
-    TEST_ASSERT_ERRNO(result == 0, "lstat on original file should succeed");
-    TEST_ASSERT(st_after.st_ino == original_ino,
-        "lstat inode must match original after copy-up");
+    /* Verify link count increased */
+    result = stat(orig_path, &st_orig);
+    TEST_ASSERT_ERRNO(result == 0, "stat on original should succeed");
+    TEST_ASSERT(st_orig.st_nlink >= 2,
+        "link count should be at least 2 after creating hard link");
 
-    result = lstat(link1_path, &st_link1);
-    TEST_ASSERT_ERRNO(result == 0, "lstat on hard link should succeed");
-    TEST_ASSERT(st_link1.st_ino == original_ino,
-        "lstat on hard link must return same inode as original");
-
-    /*
-     * Test 6: Create a second hard link and verify all three paths
-     * report the same inode.
-     */
+    /* Create another hard link and verify */
     result = link(orig_path, link2_path);
     TEST_ASSERT_ERRNO(result == 0, "creating second hard link should succeed");
 
-    result = stat(link2_path, &st_link2);
+    result = stat(link2_path, &st_link);
     TEST_ASSERT_ERRNO(result == 0, "stat on second hard link should succeed");
-    if (st_link2.st_ino != original_ino) {
-        fprintf(stderr, "  second hard link inode mismatch: expected %lu, got %lu\n",
-                (unsigned long)original_ino, (unsigned long)st_link2.st_ino);
-    }
-    TEST_ASSERT(st_link2.st_ino == original_ino,
-        "second hard link must have same inode");
+    TEST_ASSERT(st_link.st_ino == orig_ino,
+        "second hard link must have same inode as original");
 
-    /* Re-check original and first link still have correct inode */
-    result = stat(orig_path, &st_after);
-    TEST_ASSERT_ERRNO(result == 0, "stat on original after second link should succeed");
-    TEST_ASSERT(st_after.st_ino == original_ino,
-        "original inode must still be stable after multiple links");
+    /* Re-check original still has correct inode */
+    TEST_ASSERT(check_inode_stable(orig_path, orig_ino, "link (after second link)") == 0,
+        "original inode must remain stable after second link");
 
-    result = stat(link1_path, &st_link1);
-    TEST_ASSERT_ERRNO(result == 0, "stat on first link after second link should succeed");
-    TEST_ASSERT(st_link1.st_ino == original_ino,
-        "first link inode must still match original");
+    /* lstat should also show consistent inodes */
+    result = lstat(orig_path, &st_orig);
+    TEST_ASSERT_ERRNO(result == 0, "lstat on original should succeed");
+    TEST_ASSERT(st_orig.st_ino == orig_ino,
+        "lstat must return same inode after link copy-up");
 
-    /*
-     * Test 7: Verify link count is consistent.
-     * After creating two hard links, nlink should be at least 3.
-     */
-    if (st_after.st_nlink < 3) {
-        fprintf(stderr, "  nlink too low: expected >= 3, got %lu\n",
-                (unsigned long)st_after.st_nlink);
-    }
-    TEST_ASSERT(st_after.st_nlink >= 3,
-        "nlink should be at least 3 after creating two hard links");
+    result = lstat(link_path, &st_link);
+    TEST_ASSERT_ERRNO(result == 0, "lstat on hard link should succeed");
+    TEST_ASSERT(st_link.st_ino == orig_ino,
+        "lstat on hard link must return same inode");
 
-    /*
-     * Test 8: Delete one link and verify inodes remain stable.
-     */
-    result = unlink(link1_path);
+    /* Unlink one link and verify others still have correct inode */
+    result = unlink(link_path);
     TEST_ASSERT_ERRNO(result == 0, "unlink first hard link should succeed");
 
-    result = stat(orig_path, &st_after);
-    TEST_ASSERT_ERRNO(result == 0, "stat on original after unlink should succeed");
-    TEST_ASSERT(st_after.st_ino == original_ino,
-        "original inode must remain stable after unlinking a hard link");
+    TEST_ASSERT(check_inode_stable(orig_path, orig_ino, "link (after unlink)") == 0,
+        "original inode must remain stable after unlinking hard link");
 
-    result = stat(link2_path, &st_link2);
-    TEST_ASSERT_ERRNO(result == 0, "stat on remaining link should succeed");
-    TEST_ASSERT(st_link2.st_ino == original_ino,
-        "remaining link must still have original inode");
-
-    /*
-     * Test 9: fstat() on open file descriptor should also return stable inode.
-     */
-    fd = open(orig_path, O_RDONLY);
-    TEST_ASSERT_ERRNO(fd >= 0, "open original file should succeed");
-
-    result = fstat(fd, &st_after);
-    TEST_ASSERT_ERRNO(result == 0, "fstat on open fd should succeed");
-    if (st_after.st_ino != original_ino) {
-        fprintf(stderr, "  fstat inode mismatch: expected %lu, got %lu\n",
-                (unsigned long)original_ino, (unsigned long)st_after.st_ino);
-    }
-    TEST_ASSERT(st_after.st_ino == original_ino,
-        "fstat must return stable inode");
-    close(fd);
-
-    /* Also check fstat on the link */
-    fd = open(link2_path, O_RDONLY);
-    TEST_ASSERT_ERRNO(fd >= 0, "open hard link should succeed");
-
-    result = fstat(fd, &st_link2);
-    TEST_ASSERT_ERRNO(result == 0, "fstat on hard link fd should succeed");
-    TEST_ASSERT(st_link2.st_ino == original_ino,
-        "fstat on hard link must return same inode as original");
-    close(fd);
+    TEST_ASSERT(check_inode_stable(link2_path, orig_ino, "link (remaining link)") == 0,
+        "remaining hard link must have same inode after unlink");
 
     /* Clean up */
     unlink(link2_path);
-    unlink(orig_path);
+
+    return 0;
+}
+
+/**
+ * Test 7: utimes() / utimensat() triggered copy-up
+ *
+ * Changing timestamps on a base layer file should trigger copy-up
+ * while preserving the original inode number.
+ */
+static int test_utimes_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    int result;
+    struct timeval times[2];
+    struct timespec ts[2];
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_utimes_test.txt", "utimes copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_utimes_test.txt", base_path);
+
+    /* utimes - set both atime and mtime to current time */
+    times[0].tv_sec = 1000000000;  /* atime */
+    times[0].tv_usec = 0;
+    times[1].tv_sec = 1000000000;  /* mtime */
+    times[1].tv_usec = 0;
+
+    result = utimes(path, times);
+    if (result < 0 && errno == ENOSYS) {
+        printf("  (Skipping utimes copyup test - utimes not supported)\n");
+        return 0;
+    }
+    TEST_ASSERT_ERRNO(result == 0, "utimes should succeed");
+
+    /* Verify inode is stable after copy-up */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "utimes") == 0,
+        "inode must remain stable after utimes copy-up");
+
+    /* Also test utimensat */
+    ts[0].tv_sec = 1000000001;
+    ts[0].tv_nsec = 0;
+    ts[1].tv_sec = 1000000001;
+    ts[1].tv_nsec = 0;
+
+    result = utimensat(AT_FDCWD, path, ts, 0);
+    if (result < 0 && errno == ENOSYS) {
+        printf("  (utimensat not supported, skipping that part)\n");
+        return 0;
+    }
+    TEST_ASSERT_ERRNO(result == 0, "utimensat should succeed");
+
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "utimensat") == 0,
+        "inode must remain stable after utimensat copy-up");
+
+    /* Test futimens via file descriptor */
+    int fd = open(path, O_RDWR);
+    if (fd >= 0) {
+        ts[0].tv_sec = 1000000002;
+        ts[1].tv_sec = 1000000002;
+        result = futimens(fd, ts);
+        if (result == 0) {
+            struct stat st;
+            result = fstat(fd, &st);
+            TEST_ASSERT_ERRNO(result == 0, "fstat after futimens should succeed");
+            TEST_ASSERT(st.st_ino == orig_ino,
+                "fstat must return stable inode after futimens");
+        }
+        close(fd);
+    }
+
+    return 0;
+}
+
+/**
+ * Test 8: setxattr() triggered copy-up
+ *
+ * Setting extended attributes on a base layer file should trigger copy-up
+ * while preserving the original inode number.
+ *
+ * Note: Extended attributes may not be supported on all filesystems.
+ */
+static int test_xattr_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    int result;
+    const char *value = "test_value";
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_xattr_test.txt", "xattr copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_xattr_test.txt", base_path);
+
+    /* setxattr - this may trigger copy-up */
+    result = setxattr(path, "user.test_attr", value, strlen(value), 0);
+    if (result < 0) {
+        if (errno == ENOTSUP || errno == EOPNOTSUPP || errno == ENOSYS) {
+            printf("  (Skipping xattr copyup test - xattr not supported)\n");
+            return 0;
+        }
+        /* Some filesystems return EPERM even though xattr is "supported" */
+        if (errno == EPERM) {
+            printf("  (Skipping xattr copyup test - permission denied)\n");
+            return 0;
+        }
+    }
+    TEST_ASSERT_ERRNO(result == 0, "setxattr should succeed");
+
+    /* Verify inode is stable after copy-up */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "setxattr") == 0,
+        "inode must remain stable after setxattr copy-up");
+
+    /* Also test lsetxattr (for non-symlink, should behave same) */
+    result = lsetxattr(path, "user.test_attr2", value, strlen(value), 0);
+    if (result == 0) {
+        TEST_ASSERT(check_inode_stable(path, orig_ino, "lsetxattr") == 0,
+            "inode must remain stable after lsetxattr copy-up");
+    }
+
+    /* Test removexattr */
+    result = removexattr(path, "user.test_attr");
+    if (result == 0) {
+        TEST_ASSERT(check_inode_stable(path, orig_ino, "removexattr") == 0,
+            "inode must remain stable after removexattr copy-up");
+    }
+
+    return 0;
+}
+
+/**
+ * Test 9: fallocate() triggered copy-up
+ *
+ * Allocating space in a base layer file should trigger copy-up
+ * while preserving the original inode number.
+ */
+static int test_fallocate_copyup(const char *base_path) {
+    char path[512];
+    ino_t orig_ino;
+    int fd, result;
+
+    orig_ino = get_base_layer_inode(base_path, "copyup_fallocate_test.txt", "fallocate copyup");
+    if (orig_ino == 0) return 0;
+
+    snprintf(path, sizeof(path), "%s/copyup_fallocate_test.txt", base_path);
+
+    /* Open the file */
+    fd = open(path, O_RDWR);
+    TEST_ASSERT_ERRNO(fd >= 0, "open for fallocate should succeed");
+
+    /* fallocate - this triggers copy-up */
+    result = fallocate(fd, 0, 0, 1024);
+    if (result < 0) {
+        if (errno == ENOTSUP || errno == EOPNOTSUPP || errno == ENOSYS) {
+            printf("  (Skipping fallocate copyup test - fallocate not supported)\n");
+            close(fd);
+            return 0;
+        }
+    }
+    TEST_ASSERT_ERRNO(result == 0, "fallocate should succeed");
+
+    /* Verify inode is stable via fstat */
+    struct stat st;
+    result = fstat(fd, &st);
+    TEST_ASSERT_ERRNO(result == 0, "fstat after fallocate should succeed");
+    if (st.st_ino != orig_ino) {
+        fprintf(stderr, "  fstat inode mismatch after fallocate: expected %lu, got %lu\n",
+                (unsigned long)orig_ino, (unsigned long)st.st_ino);
+    }
+    TEST_ASSERT(st.st_ino == orig_ino,
+        "fstat must return stable inode after fallocate copy-up");
+    close(fd);
+
+    /* Also verify via stat */
+    TEST_ASSERT(check_inode_stable(path, orig_ino, "fallocate") == 0,
+        "inode must remain stable after fallocate copy-up");
+
+    return 0;
+}
+
+/**
+ * Main entry point for copyup inode stability tests.
+ *
+ * Runs all copy-up triggered tests and reports results.
+ */
+int test_copyup_inode_stability(const char *base_path) {
+    int result;
+
+    /* Test 1: write() triggered copy-up */
+    result = test_write_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 2: truncate() triggered copy-up */
+    result = test_truncate_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 3: chmod() triggered copy-up */
+    result = test_chmod_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 4: chown() triggered copy-up */
+    result = test_chown_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 5: rename() triggered copy-up */
+    result = test_rename_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 6: link() triggered copy-up */
+    result = test_link_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 7: utimes() triggered copy-up */
+    result = test_utimes_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 8: setxattr() triggered copy-up */
+    result = test_xattr_copyup(base_path);
+    if (result != 0) return result;
+
+    /* Test 9: fallocate() triggered copy-up */
+    result = test_fallocate_copyup(base_path);
+    if (result != 0) return result;
 
     return 0;
 }


### PR DESCRIPTION
Add comprehensive tests for inode stability during copy-up operations triggered by: write, truncate, chmod, chown, rename, link, utimes, setxattr, and fallocate. Each test verifies that the inode number remains stable after the syscall triggers copy-up from base to delta layer.

Also fix getdents64 test to loop until all directory entries are read, as the additional test files exceeded the previous 1024-byte buffer.