### PR TITLE
Add ENAMETOOLONG validation for filename length

### DIFF
--- a/cli/src/nfs.rs
+++ b/cli/src/nfs.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use agentfs_sdk::error::Error as SdkError;
+use agentfs_sdk::filesystem::FsError;
 use agentfs_sdk::{
     FileSystem, Stats, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
 };
@@ -30,6 +31,16 @@ const FS_ROOT_INO: i64 = 1;
 /// should retry the operation later. Other errors map to NFS3ERR_IO.
 fn error_to_nfsstat(e: SdkError) -> nfsstat3 {
     match e {
+        SdkError::Fs(ref fs_err) => match fs_err {
+            FsError::NotFound => nfsstat3::NFS3ERR_NOENT,
+            FsError::AlreadyExists => nfsstat3::NFS3ERR_EXIST,
+            FsError::NotEmpty => nfsstat3::NFS3ERR_NOTEMPTY,
+            FsError::NotADirectory => nfsstat3::NFS3ERR_NOTDIR,
+            FsError::IsADirectory => nfsstat3::NFS3ERR_ISDIR,
+            FsError::NameTooLong => nfsstat3::NFS3ERR_NAMETOOLONG,
+            FsError::RootOperation => nfsstat3::NFS3ERR_ACCES,
+            _ => nfsstat3::NFS3ERR_IO,
+        },
         SdkError::ConnectionPoolTimeout => nfsstat3::NFS3ERR_JUKEBOX,
         _ => nfsstat3::NFS3ERR_IO,
     }

--- a/sdk/rust/src/filesystem/agentfs.rs
+++ b/sdk/rust/src/filesystem/agentfs.rs
@@ -10,7 +10,7 @@ use turso::{Builder, Connection, Value};
 
 use super::{
     BoxedFile, DirEntry, File, FileSystem, FilesystemStats, FsError, Stats, DEFAULT_DIR_MODE,
-    DEFAULT_FILE_MODE, S_IFLNK, S_IFMT, S_IFREG,
+    DEFAULT_FILE_MODE, MAX_NAME_LEN, S_IFLNK, S_IFMT, S_IFREG,
 };
 use crate::connection_pool::ConnectionPool;
 
@@ -2380,6 +2380,9 @@ impl AgentFS {
 #[async_trait]
 impl FileSystem for AgentFS {
     async fn lookup(&self, parent_ino: i64, name: &str) -> Result<Option<Stats>> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Look up the child inode
@@ -2699,6 +2702,9 @@ impl FileSystem for AgentFS {
     }
 
     async fn mkdir(&self, parent_ino: i64, name: &str, uid: u32, gid: u32) -> Result<Stats> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Check if already exists
@@ -2761,6 +2767,9 @@ impl FileSystem for AgentFS {
         uid: u32,
         gid: u32,
     ) -> Result<(Stats, BoxedFile)> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Check if already exists
@@ -2831,6 +2840,9 @@ impl FileSystem for AgentFS {
         uid: u32,
         gid: u32,
     ) -> Result<Stats> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Check if already exists
@@ -2893,6 +2905,9 @@ impl FileSystem for AgentFS {
         uid: u32,
         gid: u32,
     ) -> Result<Stats> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Check if entry already exists
@@ -2960,6 +2975,9 @@ impl FileSystem for AgentFS {
     }
 
     async fn unlink(&self, parent_ino: i64, name: &str) -> Result<()> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Look up the child inode
@@ -3027,6 +3045,9 @@ impl FileSystem for AgentFS {
     }
 
     async fn rmdir(&self, parent_ino: i64, name: &str) -> Result<()> {
+        if name.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Look up the child inode
@@ -3104,6 +3125,9 @@ impl FileSystem for AgentFS {
     }
 
     async fn link(&self, ino: i64, newparent_ino: i64, newname: &str) -> Result<Stats> {
+        if newname.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Check if source inode exists and is not a directory
@@ -3165,6 +3189,9 @@ impl FileSystem for AgentFS {
         newparent_ino: i64,
         newname: &str,
     ) -> Result<()> {
+        if newname.len() > MAX_NAME_LEN {
+            return Err(FsError::NameTooLong.into());
+        }
         let conn = self.pool.get_connection().await?;
 
         // Get source inode

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -50,6 +50,9 @@ pub enum FsError {
 
     #[error("Cannot rename directory into its own subdirectory")]
     InvalidRename,
+
+    #[error("Filename too long")]
+    NameTooLong,
 }
 
 impl FsError {
@@ -66,9 +69,13 @@ impl FsError {
             FsError::RootOperation => libc::EPERM,
             FsError::SymlinkLoop => libc::ELOOP,
             FsError::InvalidRename => libc::EINVAL,
+            FsError::NameTooLong => libc::ENAMETOOLONG,
         }
     }
 }
+
+/// Maximum filename length in bytes.
+pub const MAX_NAME_LEN: usize = 255;
 
 // File types for mode field
 pub const S_IFMT: u32 = 0o170000; // File type mask


### PR DESCRIPTION
Reject filenames longer than 255 bytes in AgentFS filesystem operations (lookup, mkdir, create_file, mknod, symlink, unlink, rmdir, link, rename) with a NameTooLong error. Also improve NFS error_to_nfsstat to properly map FsError variants to their corresponding NFS3 status codes.