### PR TITLE
agentfs/fuse: Fix fillattr to preserve setuid, setgid, and sticky bits

### DIFF
--- a/cli/src/fuse.rs
+++ b/cli/src/fuse.rs
@@ -1098,7 +1098,7 @@ fn fillattr(stats: &Stats) -> FileAttr {
         ctime: UNIX_EPOCH + Duration::from_secs(stats.ctime as u64),
         crtime: UNIX_EPOCH,
         kind,
-        perm: (stats.mode & 0o777) as u16,
+        perm: (stats.mode & 0o7777) as u16,
         nlink: stats.nlink,
         uid: stats.uid,
         gid: stats.gid,


### PR DESCRIPTION
The perm field was masked with 0o777 instead of 0o7777, which stripped the setuid (04000), setgid (02000), and sticky (01000) bits from every file attribute response.