### PR TITLE
agentfs/nfs: Add special file support

### DIFF
--- a/cli/src/nfsserve/vfs.rs
+++ b/cli/src/nfsserve/vfs.rs
@@ -165,6 +165,20 @@ pub trait NFSFileSystem: Sync {
         auth: &auth_unix,
     ) -> Result<(fileid3, fattr3), nfsstat3>;
 
+    /// Creates a special file (device, fifo, socket) with the given attributes.
+    /// If not supported due to readonly file system
+    /// this should return Err(nfsstat3::NFS3ERR_ROFS)
+    /// The auth parameter contains the caller's credentials for ownership.
+    async fn mknod(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+        ftype: ftype3,
+        attr: sattr3,
+        rdev: specdata3,
+        auth: &auth_unix,
+    ) -> Result<(fileid3, fattr3), nfsstat3>;
+
     /// Removes a file.
     /// If not supported due to readonly file system
     /// this should return Err(nfsstat3::NFS3ERR_ROFS)


### PR DESCRIPTION
Add support for creating special files (FIFOs, character devices, block devices, and sockets) via NFS. This implements RFC 1813 MKNOD procedure which was previously returning proc_unavail.

This enables pjdfstest tests that create FIFOs, devices, and sockets.