### PR TITLE
sdk/rust: Update parent directory timestamps on mknod and create_file

### DIFF
--- a/sdk/rust/src/filesystem/agentfs.rs
+++ b/sdk/rust/src/filesystem/agentfs.rs
@@ -2831,6 +2831,13 @@ impl FileSystem for AgentFS {
 
         dentry_stmt.execute((name, parent_ino, ino)).await?;
 
+        // Update parent directory ctime and mtime
+        conn.execute(
+            "UPDATE fs_inode SET ctime = ?, mtime = ? WHERE ino = ?",
+            (now, now, parent_ino),
+        )
+        .await?;
+
         txn.commit().await?;
 
         self.dentry_cache.insert(parent_ino, name, ino);
@@ -2905,6 +2912,12 @@ impl FileSystem for AgentFS {
             .prepare_cached("UPDATE fs_inode SET nlink = nlink + 1 WHERE ino = ?")
             .await?;
         stmt.execute((ino,)).await?;
+
+        // Update parent directory ctime and mtime
+        let mut stmt = conn
+            .prepare_cached("UPDATE fs_inode SET ctime = ?, mtime = ? WHERE ino = ?")
+            .await?;
+        stmt.execute((now, now, parent_ino)).await?;
 
         // Populate dentry cache
         self.dentry_cache.insert(parent_ino, name, ino);


### PR DESCRIPTION
Update the parent directory's ctime and mtime when creating new files or special nodes, as required by POSIX.