### PR TITLE
fix(go-sdk): align default database path

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -27,7 +27,7 @@ func main() {
 
 	// Open or create an AgentFS database
 	afs, err := agentfs.Open(ctx, agentfs.AgentFSOptions{
-		ID: "my-agent", // Creates ~/.agentfs/my-agent.db
+		ID: "my-agent", // Creates .agentfs/my-agent.db
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -124,7 +124,7 @@ func main() {
 func Open(ctx context.Context, opts AgentFSOptions) (*AgentFS, error)
 
 type AgentFSOptions struct {
-    ID        string       // Agent ID (creates ~/.agentfs/{id}.db)
+    ID        string       // Agent ID (creates .agentfs/{id}.db)
     Path      string       // Explicit database path (takes precedence)
     ChunkSize int          // Chunk size for file data (default: 4096)
     Pool      PoolOptions  // Connection pool configuration

--- a/sdk/go/agentfs.go
+++ b/sdk/go/agentfs.go
@@ -48,7 +48,7 @@ var validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // Open creates or opens an AgentFS database.
 //
 // If opts.Path is provided, it is used directly as the database path.
-// If opts.ID is provided (without Path), the database is stored at ~/.agentfs/{id}.db
+// If opts.ID is provided (without Path), the database is stored at .agentfs/{id}.db
 // At least one of Path or ID must be provided.
 func Open(ctx context.Context, opts AgentFSOptions) (*AgentFS, error) {
 	dbPath, err := resolveDBPath(opts)
@@ -246,13 +246,9 @@ func resolveDBPath(opts AgentFSOptions) (string, error) {
 		return "", fmt.Errorf("invalid agent ID: must match pattern %s", validIDPattern.String())
 	}
 
-	// Default to ~/.agentfs/{id}.db
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	return filepath.Join(home, ".agentfs", opts.ID+".db"), nil
+	// Default to .agentfs/{id}.db in the current working directory,
+	// matching the other SDKs and the CLI.
+	return filepath.Join(".agentfs", opts.ID+".db"), nil
 }
 
 // initSchema creates all tables and indexes if they don't exist

--- a/sdk/go/agentfs_test.go
+++ b/sdk/go/agentfs_test.go
@@ -37,11 +37,15 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("with ID", func(t *testing.T) {
-		// Create a temp home directory
-		tmpHome := t.TempDir()
-		oldHome := os.Getenv("HOME")
-		os.Setenv("HOME", tmpHome)
-		defer os.Setenv("HOME", oldHome)
+		tmpDir := t.TempDir()
+		oldWorkingDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd failed: %v", err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Chdir failed: %v", err)
+		}
+		defer os.Chdir(oldWorkingDir)
 
 		afs, err := Open(ctx, AgentFSOptions{ID: "test-agent"})
 		if err != nil {
@@ -49,9 +53,12 @@ func TestOpen(t *testing.T) {
 		}
 		defer afs.Close()
 
-		expectedPath := filepath.Join(tmpHome, ".agentfs", "test-agent.db")
+		expectedPath := filepath.Join(".agentfs", "test-agent.db")
 		if afs.Path() != expectedPath {
 			t.Errorf("Path() = %q, want %q", afs.Path(), expectedPath)
+		}
+		if _, err := os.Stat(expectedPath); err != nil {
+			t.Errorf("database was not created in the working directory: %v", err)
 		}
 	})
 

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -8,7 +8,7 @@ import (
 // AgentFSOptions configures how AgentFS opens or creates a database
 type AgentFSOptions struct {
 	// ID is the agent identifier. If provided without Path, the database
-	// will be stored at ~/.agentfs/{id}.db
+	// will be stored at .agentfs/{id}.db
 	// Must match pattern: ^[a-zA-Z0-9_-]+$
 	ID string
 


### PR DESCRIPTION
## Summary

- Store ID-based Go SDK databases at `.agentfs/{id}.db` relative to the current working directory instead of `~/.agentfs/{id}.db`.
- Update Go SDK comments and documentation to reflect the corrected path.
- Add regression coverage verifying that the database is created under the current working directory.

## Motivation

The Rust, Python, and TypeScript SDKs, as well as the CLI and root documentation, consistently use `.agentfs/{id}.db`.

The Go SDK was the only implementation resolving ID-based databases under the user's home directory. As a result, the same agent ID could refer to different databases depending on which SDK was used.

Explicit paths supplied through `AgentFSOptions.Path` remain unchanged.

## Testing

- `go test ./...`
- `go vet ./...`